### PR TITLE
Show current total

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
@@ -378,6 +378,7 @@ public class WizardDialog extends DialogFragment implements OnClickListener {
         basalIobInsulin.setText(DecimalFormatter.to2Decimal(wizard.insulingFromBasalsIOB) + "U");
 
         correctionInsulin.setText(DecimalFormatter.to2Decimal(wizard.insulinFromCorrection) + "U");
+        calculatedTotalInsulin = wizard.calculatedTotalInsulin;
 
         if (calculatedTotalInsulin < 0) {
             total.setText(getString(R.string.missing) + " " + DecimalFormatter.to0Decimal(wizard.carbsEquivalent) + "g");
@@ -388,7 +389,6 @@ public class WizardDialog extends DialogFragment implements OnClickListener {
         }
 
         calculatedCarbs = carbsAfterConstraint;
-        calculatedTotalInsulin = wizard.calculatedTotalInsulin;
 
         if (calculatedTotalInsulin > 0d || calculatedCarbs > 0d) {
             String insulinText = calculatedTotalInsulin > 0d ? (DecimalFormatter.to2Decimal(calculatedTotalInsulin) + "U") : "";


### PR DESCRIPTION
The total of the calculation in the wizard was showing the value from the previous calculation when you enable/disable to include Bolus-IOB or Basal-IOB into the calculation.

![screenshot_2016-10-31-12-30-23](https://cloud.githubusercontent.com/assets/9692866/19853560/42ad2f8a-9f6a-11e6-809c-ab21b220edd1.png)

The button to send to the pump showed the current amount of units.