### PR TITLE
Upload only

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/Services/DataService.java
+++ b/app/src/main/java/info/nightscout/androidaps/Services/DataService.java
@@ -39,6 +39,7 @@ import info.nightscout.androidaps.events.EventTreatmentChange;
 import info.nightscout.androidaps.interfaces.PumpInterface;
 import info.nightscout.androidaps.plugins.ConfigBuilder.ConfigBuilderPlugin;
 import info.nightscout.androidaps.plugins.DanaR.History.DanaRNSHistorySync;
+import info.nightscout.androidaps.plugins.NSProfileViewer.NSProfileViewerPlugin;
 import info.nightscout.androidaps.plugins.Objectives.ObjectivesPlugin;
 import info.nightscout.androidaps.plugins.Overview.OverviewPlugin;
 import info.nightscout.androidaps.plugins.SmsCommunicator.SmsCommunicatorPlugin;
@@ -75,6 +76,8 @@ public class DataService extends IntentService {
             nsClientEnabled = true;
         }
 
+        boolean isNSProfile = ConfigBuilderPlugin.getActiveProfile().getClass().equals(NSProfileViewerPlugin.class);
+
         SharedPreferences SP = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         boolean nsUploadOnly = SP.getBoolean("ns_upload_only", false);
 
@@ -92,6 +95,9 @@ public class DataService extends IntentService {
                 // Objectives 0
                 ObjectivesPlugin.bgIsAvailableInNS = true;
                 ObjectivesPlugin.saveProgress();
+            } else if (isNSProfile && Intents.ACTION_NEW_PROFILE.equals(action)){
+                // always handle Profili if NSProfile is enabled without looking at nsUploadOnly
+                handleNewDataFromNSClient(intent);
             } else if (!nsUploadOnly &&
                     (Intents.ACTION_NEW_PROFILE.equals(action) ||
                             Intents.ACTION_NEW_TREATMENT.equals(action) ||

--- a/app/src/main/java/info/nightscout/androidaps/Services/DataService.java
+++ b/app/src/main/java/info/nightscout/androidaps/Services/DataService.java
@@ -70,26 +70,38 @@ public class DataService extends IntentService {
         if (ConfigBuilderPlugin.getActiveBgSource().getClass().equals(SourceXdripPlugin.class)) {
             xDripEnabled = true;
             nsClientEnabled = false;
-        }
-        if (ConfigBuilderPlugin.getActiveBgSource().getClass().equals(SourceNSClientPlugin.class)) {
+        } else if (ConfigBuilderPlugin.getActiveBgSource().getClass().equals(SourceNSClientPlugin.class)) {
             xDripEnabled = false;
             nsClientEnabled = true;
         }
 
+        SharedPreferences SP = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+
+        boolean nsUploadOnly = SP.getBoolean("ns_upload_only", false);
+
         if (intent != null) {
             final String action = intent.getAction();
             if (Intents.ACTION_NEW_BG_ESTIMATE.equals(action)) {
-                if (xDripEnabled)
+                if (xDripEnabled) {
                     handleNewDataFromXDrip(intent);
-            } else if (Intents.ACTION_NEW_PROFILE.equals(action) ||
-                    Intents.ACTION_NEW_TREATMENT.equals(action) ||
-                    Intents.ACTION_CHANGED_TREATMENT.equals(action) ||
-                    Intents.ACTION_REMOVED_TREATMENT.equals(action) ||
-                    Intents.ACTION_NEW_SGV.equals(action) ||
-                    Intents.ACTION_NEW_STATUS.equals(action) ||
-                    Intents.ACTION_NEW_DEVICESTATUS.equals(action) ||
-                    Intents.ACTION_NEW_CAL.equals(action) ||
-                    Intents.ACTION_NEW_MBG.equals(action)
+                }
+            } else if (Intents.ACTION_NEW_SGV.equals(action)) {
+                // always handle SGV if NS-Client is the source
+                if (nsClientEnabled) {
+                    handleNewDataFromNSClient(intent);
+                }
+                // Objectives 0
+                ObjectivesPlugin.bgIsAvailableInNS = true;
+                ObjectivesPlugin.saveProgress();
+            } else if (!nsUploadOnly &&
+                    (Intents.ACTION_NEW_PROFILE.equals(action) ||
+                            Intents.ACTION_NEW_TREATMENT.equals(action) ||
+                            Intents.ACTION_CHANGED_TREATMENT.equals(action) ||
+                            Intents.ACTION_REMOVED_TREATMENT.equals(action) ||
+                            Intents.ACTION_NEW_STATUS.equals(action) ||
+                            Intents.ACTION_NEW_DEVICESTATUS.equals(action) ||
+                            Intents.ACTION_NEW_CAL.equals(action) ||
+                            Intents.ACTION_NEW_MBG.equals(action))
                     ) {
                 handleNewDataFromNSClient(intent);
             } else if (Telephony.Sms.Intents.SMS_RECEIVED_ACTION.equals(action)) {
@@ -318,48 +330,43 @@ public class DataService extends IntentService {
         }
 
         if (intent.getAction().equals(Intents.ACTION_NEW_SGV)) {
-            if (nsClientEnabled) {
-                try {
-                    if (bundles.containsKey("sgv")) {
-                        String sgvstring = bundles.getString("sgv");
-                        JSONObject sgvJson = new JSONObject(sgvstring);
+            try {
+                if (bundles.containsKey("sgv")) {
+                    String sgvstring = bundles.getString("sgv");
+                    JSONObject sgvJson = new JSONObject(sgvstring);
+                    NSSgv nsSgv = new NSSgv(sgvJson);
+                    BgReading bgReading = new BgReading(nsSgv);
+                    if (bgReading.timeIndex < new Date().getTime() - Constants.hoursToKeepInDatabase * 60 * 60 * 1000l) {
+                        if (Config.logIncommingData)
+                            log.debug("Ignoring old BG: " + bgReading.toString());
+                        return;
+                    }
+                    MainApp.getDbHelper().getDaoBgReadings().createIfNotExists(bgReading);
+                    if (Config.logIncommingData)
+                        log.debug("ADD: Stored new BG: " + bgReading.toString());
+                }
+
+                if (bundles.containsKey("sgvs")) {
+                    String sgvstring = bundles.getString("sgvs");
+                    JSONArray jsonArray = new JSONArray(sgvstring);
+                    for (int i = 0; i < jsonArray.length(); i++) {
+                        JSONObject sgvJson = jsonArray.getJSONObject(i);
                         NSSgv nsSgv = new NSSgv(sgvJson);
                         BgReading bgReading = new BgReading(nsSgv);
                         if (bgReading.timeIndex < new Date().getTime() - Constants.hoursToKeepInDatabase * 60 * 60 * 1000l) {
                             if (Config.logIncommingData)
                                 log.debug("Ignoring old BG: " + bgReading.toString());
-                            return;
-                        }
-                        MainApp.getDbHelper().getDaoBgReadings().createIfNotExists(bgReading);
-                        if (Config.logIncommingData)
-                            log.debug("ADD: Stored new BG: " + bgReading.toString());
-                    }
-
-                    if (bundles.containsKey("sgvs")) {
-                        String sgvstring = bundles.getString("sgvs");
-                        JSONArray jsonArray = new JSONArray(sgvstring);
-                        for (int i = 0; i < jsonArray.length(); i++) {
-                            JSONObject sgvJson = jsonArray.getJSONObject(i);
-                            NSSgv nsSgv = new NSSgv(sgvJson);
-                            BgReading bgReading = new BgReading(nsSgv);
-                            if (bgReading.timeIndex < new Date().getTime() - Constants.hoursToKeepInDatabase * 60 * 60 * 1000l) {
-                                if (Config.logIncommingData)
-                                    log.debug("Ignoring old BG: " + bgReading.toString());
-                            } else {
-                                MainApp.getDbHelper().getDaoBgReadings().createIfNotExists(bgReading);
-                                if (Config.logIncommingData)
-                                    log.debug("ADD: Stored new BG: " + bgReading.toString());
-                            }
+                        } else {
+                            MainApp.getDbHelper().getDaoBgReadings().createIfNotExists(bgReading);
+                            if (Config.logIncommingData)
+                                log.debug("ADD: Stored new BG: " + bgReading.toString());
                         }
                     }
-                } catch (Exception e) {
-                    e.printStackTrace();
                 }
-                MainApp.bus().post(new EventNewBG());
+            } catch (Exception e) {
+                e.printStackTrace();
             }
-            // Objectives 0
-            ObjectivesPlugin.bgIsAvailableInNS = true;
-            ObjectivesPlugin.saveProgress();
+            MainApp.bus().post(new EventNewBG());
         }
 
         if (intent.getAction().equals(Intents.ACTION_NEW_MBG)) {

--- a/app/src/main/java/info/nightscout/androidaps/Services/DataService.java
+++ b/app/src/main/java/info/nightscout/androidaps/Services/DataService.java
@@ -76,7 +76,6 @@ public class DataService extends IntentService {
         }
 
         SharedPreferences SP = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-
         boolean nsUploadOnly = SP.getBoolean("ns_upload_only", false);
 
         if (intent != null) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/TempBasals/TempBasalsPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/TempBasals/TempBasalsPlugin.java
@@ -121,7 +121,7 @@ public class TempBasalsPlugin implements PluginBase, TempBasalsInterface {
             queryBuilderExt.orderBy("timeIndex", false);
             Where whereExt = queryBuilderExt.where();
             whereExt.eq("isExtended", true);
-            queryBuilderExt.limit(5L);
+            queryBuilderExt.limit(30L);
             PreparedQuery<TempBasal> preparedQueryExt = queryBuilderExt.prepare();
             extendedBoluses = dao.query(preparedQueryExt);
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/TreatmentsFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/TreatmentsFragment.java
@@ -3,7 +3,9 @@ package info.nightscout.androidaps.plugins.Treatments;
 import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.CardView;
@@ -34,6 +36,7 @@ import info.nightscout.androidaps.events.EventTreatmentChange;
 import info.nightscout.androidaps.interfaces.FragmentBase;
 import info.nightscout.client.data.NSProfile;
 import info.nightscout.utils.DecimalFormatter;
+import info.nightscout.utils.ToastUtils;
 
 public class TreatmentsFragment extends Fragment implements View.OnClickListener, FragmentBase {
     private static Logger log = LoggerFactory.getLogger(TreatmentsFragment.class);
@@ -148,21 +151,26 @@ public class TreatmentsFragment extends Fragment implements View.OnClickListener
     public void onClick(View view) {
         switch (view.getId()) {
             case R.id.treatments_reshreshfromnightscout:
-                AlertDialog.Builder builder = new AlertDialog.Builder(this.getContext());
-                builder.setTitle(this.getContext().getString(R.string.confirmation));
-                builder.setMessage(this.getContext().getString(R.string.refreshfromnightscout));
-                builder.setPositiveButton(this.getContext().getString(R.string.ok), new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        MainApp.getDbHelper().resetTreatments();
-                        treatmentsPlugin.initializeData();
-                        updateGUI();
-                        Intent restartNSClient = new Intent(Intents.ACTION_RESTART);
-                        MainApp.instance().getApplicationContext().sendBroadcast(restartNSClient);
-                    }
-                });
-                builder.setNegativeButton(this.getContext().getString(R.string.cancel), null);
-                builder.show();
-
+                SharedPreferences SP = PreferenceManager.getDefaultSharedPreferences(getContext());
+                boolean nsUploadOnly = SP.getBoolean("ns_upload_only", false);
+                if(nsUploadOnly){
+                    ToastUtils.showToastInUiThread(getContext(),this.getContext().getString(R.string.ns_upload_only_enabled));
+                } else {
+                    AlertDialog.Builder builder = new AlertDialog.Builder(this.getContext());
+                    builder.setTitle(this.getContext().getString(R.string.confirmation));
+                    builder.setMessage(this.getContext().getString(R.string.refreshfromnightscout));
+                    builder.setPositiveButton(this.getContext().getString(R.string.ok), new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int id) {
+                            MainApp.getDbHelper().resetTreatments();
+                            treatmentsPlugin.initializeData();
+                            updateGUI();
+                            Intent restartNSClient = new Intent(Intents.ACTION_RESTART);
+                            MainApp.instance().getApplicationContext().sendBroadcast(restartNSClient);
+                        }
+                    });
+                    builder.setNegativeButton(this.getContext().getString(R.string.cancel), null);
+                    builder.show();
+                }
                 break;
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -336,6 +336,6 @@
     <string name="ko_lang">Korean</string>
     <string name="actions">Actions</string>
     <string name="ns_upload_only">NS upload only (disabled sync)</string>
-    <string name="ns_upload_only_summary">NS upload only. Not effective on SGV unless a local source like xDrip is selected.</string>
+    <string name="ns_upload_only_summary">NS upload only. Not effective on SGV unless a local source like xDrip is selected. Not effective on Profiles while NS-Profiles is used.</string>
     <string name="ns_upload_only_enabled">Please deactivate "NS upload only" to use this feature.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -337,5 +337,5 @@
     <string name="actions">Actions</string>
     <string name="ns_upload_only">NS upload only (disabled sync)</string>
     <string name="ns_upload_only_summary">NS upload only. Not effective on SGV unless a local source like xDrip is selected.</string>
-
+    <string name="ns_upload_only_enabled">Please deactivate "NS upload only" to use this feature.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,5 +335,7 @@
     <string name="correctionbous">Corr</string>
     <string name="ko_lang">Korean</string>
     <string name="actions">Actions</string>
+    <string name="ns_upload_only">NS upload only (disabled sync)</string>
+    <string name="ns_upload_only_summary">NS upload only. Not effective on SGV unless a local source like xDrip is selected.</string>
 
 </resources>

--- a/app/src/main/res/xml/pref_nightscout.xml
+++ b/app/src/main/res/xml/pref_nightscout.xml
@@ -10,6 +10,11 @@
             android:title="@string/syncprofiletopump_title" />
         <SwitchPreference
             android:defaultValue="false"
+            android:key="ns_upload_only"
+            android:title="@string/ns_upload_only"
+            android:summary="@string/ns_upload_only_summary"/>
+        <SwitchPreference
+            android:defaultValue="false"
             android:key="ns_sync_use_absolute"
             android:title="@string/ns_sync_use_absolute_title" />
 


### PR DESCRIPTION
Tested:

* Adding a treatment via NS works on "upload only" disabled.
* Adding a treatment via NS will be blocked on "upload only" enabled.
* Modifying a treatment will be blocked on "upload only".
* SGV still come through even if "upload only" enabled.
* Button in Treatments-Fragment will just show a toast if "upload only" is enabled.
* Button in Treatments-Fragment works (and downloads old treatments) if "upload only" is disabled.