### PR TITLE
Show DanaR as part of profile name

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/DanaR/DanaRPump.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/DanaR/DanaRPump.java
@@ -22,6 +22,8 @@ public class DanaRPump {
     public static final int UNITS_MGDL = 0;
     public static final int UNITS_MMOL = 1;
 
+    public static final String PROFILE_PREFIX = "DanaR-";
+
     public Date lastConnection = new Date(0);
     public Date lastSettingsRead = new Date(0);
 
@@ -106,7 +108,7 @@ public class DanaRPump {
         double car = SafeParse.stringToDouble(SP.getString("danarprofile_car", "20"));
 
         try {
-            json.put("defaultProfile", "" + (activeProfile + 1));
+            json.put("defaultProfile", PROFILE_PREFIX + (activeProfile + 1));
             json.put("store", store);
             profile.put("dia", dia);
 
@@ -139,20 +141,20 @@ public class DanaRPump {
                 } else {
                     time = df.format(h) + ":00";
                 }
-                  basals.put(new JSONObject().put("time", time).put("timeAsSeconds", h * basalIncrement).put("value", pumpProfiles[activeProfile][h]));
+                basals.put(new JSONObject().put("time", time).put("timeAsSeconds", h * basalIncrement).put("value", pumpProfiles[activeProfile][h]));
             }
             profile.put("basal", basals);
 
             profile.put("target_low", new JSONArray().put(new JSONObject().put("time", "00:00").put("timeAsSeconds", 0).put("value", currentTarget)));
             profile.put("target_high", new JSONArray().put(new JSONObject().put("time", "00:00").put("timeAsSeconds", 0).put("value", currentTarget)));
             profile.put("units", units == UNITS_MGDL ? Constants.MGDL : Constants.MMOL);
-            store.put("" + (activeProfile + 1), profile);
+            store.put(PROFILE_PREFIX + (activeProfile + 1), profile);
         } catch (JSONException e) {
             e.printStackTrace();
         } catch (Exception e) {
             return null;
         }
-        return new NSProfile(json, "" + (activeProfile + 1));
+        return new NSProfile(json, PROFILE_PREFIX + (activeProfile + 1));
     }
 
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/SimpleProfile/SimpleProfilePlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/SimpleProfile/SimpleProfilePlugin.java
@@ -217,7 +217,7 @@ public class SimpleProfilePlugin implements PluginBase, ProfileInterface {
         JSONObject profile = new JSONObject();
 
         try {
-            json.put("defaultProfile", "Profile");
+            json.put("defaultProfile", "SimpleProfile");
             json.put("store", store);
             profile.put("dia", dia);
             profile.put("carbratio", new JSONArray().put(new JSONObject().put("timeAsSeconds", 0).put("value", ic)));
@@ -227,11 +227,11 @@ public class SimpleProfilePlugin implements PluginBase, ProfileInterface {
             profile.put("target_low", new JSONArray().put(new JSONObject().put("timeAsSeconds", 0).put("value", targetLow)));
             profile.put("target_high", new JSONArray().put(new JSONObject().put("timeAsSeconds", 0).put("value", targetHigh)));
             profile.put("units", mgdl ? Constants.MGDL : Constants.MMOL);
-            store.put("Profile", profile);
+            store.put("SimpleProfile", profile);
         } catch (JSONException e) {
             e.printStackTrace();
         }
-        convertedProfile = new NSProfile(json, null);
+        convertedProfile = new NSProfile(json, "SimpleProfile");
     }
 
     @Override


### PR DESCRIPTION
Now that the profile name is shown in the overview, prefixing the profile names returned from the DanaR profile plugin seems to make sense to me:

![screenshot_2016-11-11-01-36-05](https://cloud.githubusercontent.com/assets/9692866/20200433/7946afb8-a7b1-11e6-96c2-48ec908d5cd4.png)
