### PR TITLE
fix autosens adjust BG targets

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/interfaces/ConstraintsInterface.java
+++ b/app/src/main/java/info/nightscout/androidaps/interfaces/ConstraintsInterface.java
@@ -13,7 +13,7 @@ public interface ConstraintsInterface {
 
     boolean isAutosensModeEnabled();
 
-    boolean isAMAModeEnabled();
+    boolean isAutosensAdjustTargetsEnabled();
 
     Double applyBasalConstraints(Double absoluteRate);
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/ConfigBuilder/ConfigBuilderPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/ConfigBuilder/ConfigBuilderPlugin.java
@@ -696,15 +696,15 @@ public class ConfigBuilderPlugin implements PluginBase, PumpInterface, Constrain
     }
 
     @Override
-    public boolean isAMAModeEnabled() {
+    public boolean isAutosensAdjustTargetsEnabled() {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(MainApp.instance().getApplicationContext());
-        boolean result = preferences.getBoolean("openapsama_useautosens", false);
+        boolean result = preferences.getBoolean("openapsama_autosens_adjust_targets", false);
 
         ArrayList<PluginBase> constraintsPlugins = MainApp.getSpecificPluginsListByInterface(ConstraintsInterface.class);
         for (PluginBase p : constraintsPlugins) {
             ConstraintsInterface constrain = (ConstraintsInterface) p;
             if (!p.isEnabled(PluginBase.CONSTRAINTS)) continue;
-            result = result && constrain.isAMAModeEnabled();
+            result = result && constrain.isAutosensAdjustTargetsEnabled();
         }
         return result;
     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
@@ -232,7 +232,7 @@ public class DetermineBasalAdapterAMAJS {
         mProfile.add("skip_neutral_temps", true);
         mProfile.add("current_basal", pump.getBaseBasalRate());
         mProfile.add("temptargetSet", tempTargetSet);
-        mProfile.add("autosens_adjust_targets", MainApp.getConfigBuilder().isAMAModeEnabled());
+        mProfile.add("autosens_adjust_targets", MainApp.getConfigBuilder().isAutosensAdjustTargetsEnabled());
         mProfile.add("min_5m_carbimpact", min_5m_carbimpact);
         mV8rt.add(PARAM_profile, mProfile);
 
@@ -258,13 +258,9 @@ public class DetermineBasalAdapterAMAJS {
         mMealData.add("mealCOB", mealData.mealCOB);
         mV8rt.add(PARAM_meal_data, mMealData);
 
-        if (MainApp.getConfigBuilder().isAMAModeEnabled()) {
-            mAutosensData = new V8Object(mV8rt);
-            mAutosensData.add("ratio", autosensDataRatio);
-            mV8rt.add(PARAM_autosens_data, mAutosensData);
-        } else {
-            mV8rt.addUndefined(PARAM_autosens_data);
-        }
+        mAutosensData = new V8Object(mV8rt);
+        mAutosensData.add("ratio", autosensDataRatio);
+        mV8rt.add(PARAM_autosens_data, mAutosensData);
     }
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -404,5 +404,5 @@
     <string name="array_of_elements">Array of %d elements.\nActual value:</string>
     <string name="openapsma_autosensdata_label">Autosens data</string>
     <string name="openapsma_scriptdebugdata_label">Script debug</string>
-    <string name="openapsama_useautosens">Use AMA autosens feature</string>
+    <string name="openapsama_autosens_adjust_targets">Allow autosens to adjust BG targets</string>
 </resources>

--- a/app/src/main/res/xml/pref_openapsama.xml
+++ b/app/src/main/res/xml/pref_openapsama.xml
@@ -6,8 +6,8 @@
 
         <SwitchPreference
             android:defaultValue="false"
-            android:key="openapsama_useautosens"
-            android:title="@string/openapsama_useautosens" />
+            android:key="openapsama_autosens_adjust_targets"
+            android:title="@string/openapsama_autosens_adjust_targets" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
regarding to that: 
https://openaps.readthedocs.io/en/latest/docs/walkthrough/phase-3/beyond-low-glucose-suspend.html
the autosens_adjust_targets setting is only for allow autosens to adjust the BG target not for enabling or disabling the wohle autosens feature