### PR TITLE
fix autosens adjust BG targets

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/Constants.java
+++ b/app/src/main/java/info/nightscout/androidaps/Constants.java
@@ -36,6 +36,7 @@ public class Constants {
     public static final int BOLUSSNOOZE_DIA_ADVISOR = 2;
     public static final double AUTOSENS_MAX = 1.2d;
     public static final double AUTOSENS_MIN = 0.7d;
+    public static final boolean AUTOSENS_ADJUST_TARGETS = false;
     public static final double MIN_5M_CARBIMPACT = 3d;
 
     // Circadian Percentage Profile

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
@@ -232,7 +232,7 @@ public class DetermineBasalAdapterAMAJS {
         mProfile.add("skip_neutral_temps", true);
         mProfile.add("current_basal", pump.getBaseBasalRate());
         mProfile.add("temptargetSet", tempTargetSet);
-        mProfile.add("autosens_adjust_targets", MainApp.getConfigBuilder().isAMAModeEnabled());
+        mProfile.add("autosens_adjust_targets", Constants.AUTOSENS_ADJUST_TARGETS);
         mProfile.add("min_5m_carbimpact", min_5m_carbimpact);
         mV8rt.add(PARAM_profile, mProfile);
 


### PR DESCRIPTION
regarding to that: 
https://openaps.readthedocs.io/en/latest/docs/walkthrough/phase-3/beyond-low-glucose-suspend.html
the autosens_adjust_targets setting is only for allow autosens to adjust the BG target not for enabling or disabling the wohle autosens feature