### PR TITLE
Preference Switches for Autosens

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/Constants.java
+++ b/app/src/main/java/info/nightscout/androidaps/Constants.java
@@ -36,14 +36,13 @@ public class Constants {
     public static final int BOLUSSNOOZE_DIA_ADVISOR = 2;
     public static final double AUTOSENS_MAX = 1.2d;
     public static final double AUTOSENS_MIN = 0.7d;
-    public static final boolean AUTOSENS_ADJUST_TARGETS = false;
     public static final double MIN_5M_CARBIMPACT = 3d;
 
     // Circadian Percentage Profile
     public static final int CPP_MIN_PERCENTAGE = 50;
     public static final int CPP_MAX_PERCENTAGE = 200;
 
-
+    // Defaults for settings
     public static final String MAX_BG_DEFAULT_MGDL = "180";
     public static final String MAX_BG_DEFAULT_MMOL = "10";
     public static final String MIN_BG_DEFAULT_MGDL = "100";

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/AutosensResult.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/AutosensResult.java
@@ -7,11 +7,13 @@ import org.json.JSONObject;
  * Created by mike on 06.01.2017.
  */
 public class AutosensResult {
-    public double ratio;
-    public double carbsAbsorbed;
-    public String sensResult;
-    public String pastSensitivity;
-    public String ratioLimit;
+
+    //default values to show when autosens algorithm is not called
+    public double ratio = 1d;
+    public double carbsAbsorbed = 0d;
+    public String sensResult = "autosens deactivated";
+    public String pastSensitivity = "";
+    public String ratioLimit = "";
 
     public JSONObject json() {
         JSONObject ret = new JSONObject();

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
@@ -1,5 +1,8 @@
 package info.nightscout.androidaps.plugins.OpenAPSAMA;
 
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
 import com.eclipsesource.v8.JavaVoidCallback;
 import com.eclipsesource.v8.V8;
 import com.eclipsesource.v8.V8Array;
@@ -214,6 +217,8 @@ public class DetermineBasalAdapterAMAJS {
                         double min_5m_carbimpact) {
 
         String units = profile.getUnits();
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(MainApp.instance().getApplicationContext());
+        boolean autosensAdustTargets = preferences.getBoolean("openapsama_autosens_adjusttargets", false);
 
         mProfile = new V8Object(mV8rt);
         mProfile.add("max_iob", maxIob);
@@ -232,7 +237,7 @@ public class DetermineBasalAdapterAMAJS {
         mProfile.add("skip_neutral_temps", true);
         mProfile.add("current_basal", pump.getBaseBasalRate());
         mProfile.add("temptargetSet", tempTargetSet);
-        mProfile.add("autosens_adjust_targets", Constants.AUTOSENS_ADJUST_TARGETS);
+        mProfile.add("autosens_adjust_targets", autosensAdustTargets);
         mProfile.add("min_5m_carbimpact", min_5m_carbimpact);
         mV8rt.add(PARAM_profile, mProfile);
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/OpenAPSAMAPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/OpenAPSAMAPlugin.java
@@ -203,7 +203,12 @@ public class OpenAPSAMAPlugin implements PluginBase, APSInterface {
         long oldestDataAvailable = MainApp.getConfigBuilder().getActiveTempBasals().oldestDataAvaialable();
         List<BgReading> bgReadings = MainApp.getDbHelper().getBgreadingsDataFromTime(Math.max(oldestDataAvailable, (long) (new Date().getTime() - 60 * 60 * 1000L * (24 + profile.getDia()))), false);
         log.debug("Limiting data to oldest available temps: " + new Date(oldestDataAvailable).toString() + " (" + bgReadings.size() + " records)");
-        lastAutosensResult = Autosens.detectSensitivityandCarbAbsorption(bgReadings, new Date().getTime());
+
+        if(MainApp.getConfigBuilder().isAMAModeEnabled()){
+            lastAutosensResult = Autosens.detectSensitivityandCarbAbsorption(bgReadings, new Date().getTime());
+        } else {
+            lastAutosensResult = new AutosensResult();
+        }
 
         determineBasalAdapterAMAJS.setData(profile, maxIob, maxBasal, minBg, maxBg, targetBg, pump, iobArray, glucoseStatus, mealData,
                 lastAutosensResult.ratio, //autosensDataRatio

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -428,4 +428,5 @@
     <string name="danar_stats_tbb2">Total Base Basal ²</string>
     <string name="initializing">Initializing ...</string>
     <string name="careportal_temptarget">Temporary Target</string>
+    <string name="openapsama_autosens_adjusttargets">Allow autosens to adjust targets</string>
 </resources>

--- a/app/src/main/res/xml/pref_openapsama.xml
+++ b/app/src/main/res/xml/pref_openapsama.xml
@@ -9,6 +9,13 @@
             android:key="openapsama_useautosens"
             android:title="@string/openapsama_useautosens" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="openapsama_autosens_adjusttargets"
+            android:dependency="openapsama_useautosens"
+            android:title="@string/openapsama_autosens_adjusttargets"/>
+
+
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
1) Moved the option to enable/disable changing targets with autosens from Constants to a setting.
2) Don't prepare the autosens data (more time consuming than the rest of the OpanapsAMA call) if it is not used (switched off in settings).