### PR TITLE
Settings for deltas

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/Constants.java
+++ b/app/src/main/java/info/nightscout/androidaps/Constants.java
@@ -53,7 +53,7 @@ public class Constants {
     // Very Hard Limits Ranges
     // First value is the Lowest and second value is the Highest a Limit can define
     public static final int[] VERY_HARD_LIMIT_MIN_BG = {72,180};
-    public static final int[] VERY_HARD_LIMIT_MAX_BG = {99,270};
+    public static final int[] VERY_HARD_LIMIT_MAX_BG = {90,270};
     public static final int[] VERY_HARD_LIMIT_TARGET_BG = {80,200};
 
     // Very Hard Limits Ranges for Temp Targets

--- a/app/src/main/java/info/nightscout/androidaps/PreferencesActivity.java
+++ b/app/src/main/java/info/nightscout/androidaps/PreferencesActivity.java
@@ -104,6 +104,7 @@ public class PreferencesActivity extends PreferenceActivity implements SharedPre
             if (Config.SMSCOMMUNICATORENABLED)
                 addPreferencesFromResource(R.xml.pref_smscommunicator);
             addPreferencesFromResource(R.xml.pref_others);
+            addPreferencesFromResource(R.xml.pref_advanced);
             initSummary(getPreferenceScreen());
         }
 

--- a/app/src/main/java/info/nightscout/androidaps/data/GlucoseStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/data/GlucoseStatus.java
@@ -1,5 +1,7 @@
 package info.nightscout.androidaps.data;
 
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.text.Html;
 import android.text.Spanned;
@@ -24,6 +26,7 @@ public class GlucoseStatus {
     public double avgdelta = 0d;
     public double short_avgdelta = 0d;
     public double long_avgdelta = 0d;
+
 
     @Override
     public String toString() {
@@ -54,6 +57,8 @@ public class GlucoseStatus {
 
     @Nullable
     public static GlucoseStatus getGlucoseStatusData() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(MainApp.instance());
+
         // load 45min
         long fromtime = (long) (new Date().getTime() - 60 * 1000L * 45);
         List<BgReading> data = MainApp.getDbHelper().getBgreadingsDataFromTime(fromtime, false);
@@ -104,8 +109,15 @@ public class GlucoseStatus {
 
         GlucoseStatus status = new GlucoseStatus();
         status.glucose = now.value;
-        status.delta = average(last_deltas);
+
         status.short_avgdelta = average(short_deltas);
+
+        if(prefs.getBoolean("always_use_shortavg",false) || (last_deltas.isEmpty() && prefs.getBoolean("default_to_shortavg",false))){
+            status.delta = status.short_avgdelta;
+        } else {
+            status.delta = average(last_deltas);
+        }
+
         status.long_avgdelta = average(long_deltas);
         status.avgdelta = status.short_avgdelta; // for OpenAPS MA
 

--- a/app/src/main/java/info/nightscout/androidaps/data/GlucoseStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/data/GlucoseStatus.java
@@ -112,7 +112,7 @@ public class GlucoseStatus {
 
         status.short_avgdelta = average(short_deltas);
 
-        if(prefs.getBoolean("always_use_shortavg",false) || (last_deltas.isEmpty() && prefs.getBoolean("default_to_shortavg",false))){
+        if(prefs.getBoolean("always_use_shortavg",false) || last_deltas.isEmpty()){
             status.delta = status.short_avgdelta;
         } else {
             status.delta = average(last_deltas);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -449,8 +449,7 @@
     <string name="smscommunicator_shortname">SMS</string>
     <string name="short_tabtitles">Shorten tab titles</string>
     <string name="prefs_delta_title">Delta Settings</string>
-    <string name="default_to_shortavg">Default to short average delta</string>
-    <string name="default_to_shortavg_summary">Use short average delta when simple delta cannot be computed.</string>
     <string name="always_use_shortavg">Always use short average delta instead of simple delta</string>
     <string name="always_use_shortavg_summary">Useful when data from unfiltered sources like xDrip gets noisy.</string>
+    <string name="advancedsettings_title">Advanced Settings</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -448,4 +448,9 @@
     <string name="wear_shortname">WEAR</string>
     <string name="smscommunicator_shortname">SMS</string>
     <string name="short_tabtitles">Shorten tab titles</string>
+    <string name="prefs_delta_title">Delta Settings</string>
+    <string name="default_to_shortavg">Default to short average delta</string>
+    <string name="default_to_shortavg_summary">Use short average delta when simple delta cannot be computed.</string>
+    <string name="always_use_shortavg">Always use short average delta instead of simple delta</string>
+    <string name="always_use_shortavg_summary">Useful when data from unfiltered sources like xDrip gets noisy.</string>
 </resources>

--- a/app/src/main/res/xml/pref_advanced.xml
+++ b/app/src/main/res/xml/pref_advanced.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceCategory
+        android:key="advanced"
+        android:title="@string/advancedsettings_title">
+        <PreferenceScreen
+            android:title="@string/advancedsettings_title">
+            <PreferenceCategory
+                android:title="@string/nightscout">
+                <SwitchPreference
+                    android:defaultValue="false"
+                    android:key="ns_upload_only"
+                    android:title="@string/ns_upload_only"
+                    android:summary="@string/ns_upload_only_summary"/>
+                <SwitchPreference
+                    android:defaultValue="false"
+                    android:key="ns_sync_use_absolute"
+                    android:title="@string/ns_sync_use_absolute_title" />
+            </PreferenceCategory>
+            <PreferenceCategory
+                android:title="@string/openapsma">
+                <SwitchPreference
+                    android:defaultValue="false"
+                    android:key="always_use_shortavg"
+                    android:title="@string/always_use_shortavg"
+                    android:summary="@string/always_use_shortavg_summary"/>
+            </PreferenceCategory>
+        </PreferenceScreen>
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/app/src/main/res/xml/pref_nightscout.xml
+++ b/app/src/main/res/xml/pref_nightscout.xml
@@ -8,16 +8,6 @@
             android:defaultValue="false"
             android:key="syncprofiletopump"
             android:title="@string/syncprofiletopump_title" />
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="ns_upload_only"
-            android:title="@string/ns_upload_only"
-            android:summary="@string/ns_upload_only_summary"/>
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="ns_sync_use_absolute"
-            android:title="@string/ns_sync_use_absolute_title" />
-
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/pref_openapsma.xml
+++ b/app/src/main/res/xml/pref_openapsma.xml
@@ -30,6 +30,18 @@
             android:key="openapsma_max_iob"
             android:numeric="decimal"
             android:title="@string/openapsma_maxiob_summary" />
+        <PreferenceScreen
+            android:title="@string/prefs_delta_title">
+            <SwitchPreference
+                android:defaultValue="false"
+                android:key="default_to_shortavg"
+                android:title="@string/default_to_shortavg"
+                android:summary="@string/default_to_shortavg_summary"/>
+            <SwitchPreference
+                android:defaultValue="false"
+                android:key="always_use_shortavg"
+                android:title="@string/always_use_shortavg"
+                android:summary="@string/always_use_shortavg_summary"/>
+        </PreferenceScreen>
     </PreferenceCategory>
-
 </PreferenceScreen>

--- a/app/src/main/res/xml/pref_openapsma.xml
+++ b/app/src/main/res/xml/pref_openapsma.xml
@@ -30,18 +30,5 @@
             android:key="openapsma_max_iob"
             android:numeric="decimal"
             android:title="@string/openapsma_maxiob_summary" />
-        <PreferenceScreen
-            android:title="@string/prefs_delta_title">
-            <SwitchPreference
-                android:defaultValue="false"
-                android:key="default_to_shortavg"
-                android:title="@string/default_to_shortavg"
-                android:summary="@string/default_to_shortavg_summary"/>
-            <SwitchPreference
-                android:defaultValue="false"
-                android:key="always_use_shortavg"
-                android:title="@string/always_use_shortavg"
-                android:summary="@string/always_use_shortavg_summary"/>
-        </PreferenceScreen>
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Includes the suggestion by Scott to use the *short average delta* as delta on unfiltered sources like xDrip/G4 when values get noisy.

Also gives the option to use the *short average delta* as delta when the delta cannot be computed - similar to the corrected "OpenAPS MA" behaviour.