### PR TITLE
fix bgi in autosens

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/Autosens.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/Autosens.java
@@ -98,7 +98,7 @@ public class Autosens {
 //            avgDelta = avgDelta.toFixed(2);
             IobTotal iob = IobTotal.calulateFromTreatmentsAndTemps(bgTime);
 
-            double bgi = Math.round((-iob.activity * sens * 5) * 100) / 100;
+            double bgi = Math.round((-iob.activity * sens * 5) * 100) / 100d;
 //            bgi = bgi.toFixed(2);
             //console.error(delta);
             double deviation = delta - bgi;


### PR DESCRIPTION
bgi's most of the time where 0 or got truncated to full integers.

Example from tonight: autosens result factor from 1.0 before and 1.09 after this.