### PR TITLE
move evaluation of always_use_shortavg setting to the OAPS plugins

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/data/GlucoseStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/data/GlucoseStatus.java
@@ -131,7 +131,7 @@ public class GlucoseStatus {
 
         status.short_avgdelta = average(short_deltas);
 
-        if (prefs.getBoolean("always_use_shortavg", false) || last_deltas.isEmpty()) {
+        if (last_deltas.isEmpty()) {
             status.delta = status.short_avgdelta;
         } else {
             status.delta = average(last_deltas);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
@@ -1,7 +1,5 @@
 package info.nightscout.androidaps.plugins.OpenAPSAMA;
 
-import android.preference.PreferenceManager;
-
 import com.eclipsesource.v8.JavaVoidCallback;
 import com.eclipsesource.v8.V8;
 import com.eclipsesource.v8.V8Array;

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
@@ -1,5 +1,7 @@
 package info.nightscout.androidaps.plugins.OpenAPSAMA;
 
+import android.preference.PreferenceManager;
+
 import com.eclipsesource.v8.JavaVoidCallback;
 import com.eclipsesource.v8.V8;
 import com.eclipsesource.v8.V8Array;
@@ -243,7 +245,12 @@ public class DetermineBasalAdapterAMAJS {
 
         mGlucoseStatus = new V8Object(mV8rt);
         mGlucoseStatus.add("glucose", glucoseStatus.glucose);
-        mGlucoseStatus.add("delta", glucoseStatus.delta);
+
+        if(PreferenceManager.getDefaultSharedPreferences(MainApp.instance()).getBoolean("always_use_shortavg", false)){
+            mGlucoseStatus.add("delta", glucoseStatus.short_avgdelta);
+        } else {
+            mGlucoseStatus.add("delta", glucoseStatus.delta);
+        }
         mGlucoseStatus.add("short_avgdelta", glucoseStatus.short_avgdelta);
         mGlucoseStatus.add("long_avgdelta", glucoseStatus.long_avgdelta);
         mV8rt.add(PARAM_glucoseStatus, mGlucoseStatus);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
@@ -246,7 +246,7 @@ public class DetermineBasalAdapterAMAJS {
         mGlucoseStatus = new V8Object(mV8rt);
         mGlucoseStatus.add("glucose", glucoseStatus.glucose);
 
-        if(PreferenceManager.getDefaultSharedPreferences(MainApp.instance()).getBoolean("always_use_shortavg", false)){
+        if(SP.getBoolean("always_use_shortavg", false)){
             mGlucoseStatus.add("delta", glucoseStatus.short_avgdelta);
         } else {
             mGlucoseStatus.add("delta", glucoseStatus.delta);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSMA/DetermineBasalAdapterMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSMA/DetermineBasalAdapterMAJS.java
@@ -1,7 +1,5 @@
 package info.nightscout.androidaps.plugins.OpenAPSMA;
 
-import android.preference.PreferenceManager;
-
 import com.eclipsesource.v8.JavaVoidCallback;
 import com.eclipsesource.v8.V8;
 import com.eclipsesource.v8.V8Array;
@@ -15,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import info.nightscout.androidaps.Config;
-import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.data.GlucoseStatus;
 import info.nightscout.androidaps.data.IobTotal;
 import info.nightscout.androidaps.data.MealData;

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSMA/DetermineBasalAdapterMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSMA/DetermineBasalAdapterMAJS.java
@@ -22,6 +22,7 @@ import info.nightscout.androidaps.data.MealData;
 import info.nightscout.androidaps.interfaces.PumpInterface;
 import info.nightscout.androidaps.plugins.Loop.ScriptReader;
 import info.nightscout.androidaps.plugins.NSClientInternal.data.NSProfile;
+import info.nightscout.utils.SP;
 
 public class DetermineBasalAdapterMAJS {
     private static Logger log = LoggerFactory.getLogger(DetermineBasalAdapterMAJS.class);
@@ -254,7 +255,7 @@ public class DetermineBasalAdapterMAJS {
         mIobData.add("hightempinsulin", iobData.hightempinsulin);
 
         mGlucoseStatus.add("glucose", glucoseStatus.glucose);
-        if(PreferenceManager.getDefaultSharedPreferences(MainApp.instance()).getBoolean("always_use_shortavg", false)){
+        if(SP.getBoolean("always_use_shortavg", false)){
             mGlucoseStatus.add("delta", glucoseStatus.short_avgdelta);
         } else {
             mGlucoseStatus.add("delta", glucoseStatus.delta);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSMA/DetermineBasalAdapterMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSMA/DetermineBasalAdapterMAJS.java
@@ -1,5 +1,7 @@
 package info.nightscout.androidaps.plugins.OpenAPSMA;
 
+import android.preference.PreferenceManager;
+
 import com.eclipsesource.v8.JavaVoidCallback;
 import com.eclipsesource.v8.V8;
 import com.eclipsesource.v8.V8Array;
@@ -13,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import info.nightscout.androidaps.Config;
+import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.data.GlucoseStatus;
 import info.nightscout.androidaps.data.IobTotal;
 import info.nightscout.androidaps.data.MealData;
@@ -251,7 +254,11 @@ public class DetermineBasalAdapterMAJS {
         mIobData.add("hightempinsulin", iobData.hightempinsulin);
 
         mGlucoseStatus.add("glucose", glucoseStatus.glucose);
-        mGlucoseStatus.add("delta", glucoseStatus.delta);
+        if(PreferenceManager.getDefaultSharedPreferences(MainApp.instance()).getBoolean("always_use_shortavg", false)){
+            mGlucoseStatus.add("delta", glucoseStatus.short_avgdelta);
+        } else {
+            mGlucoseStatus.add("delta", glucoseStatus.delta);
+        }
         mGlucoseStatus.add("avgdelta", glucoseStatus.avgdelta);
 
         mMealData.add("carbs", mealData.carbs);


### PR DESCRIPTION
For the overview and the watch we still may use the standard delta, even if this setting is enabled. (Also good to check that it is the same as in xDrip e.g.)