### PR TITLE
visualize absolute rate emulation as percentage

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/db/TemporaryBasal.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/TemporaryBasal.java
@@ -273,7 +273,7 @@ public class TemporaryBasal implements Interval {
 
     public String toStringShort() {
         if (isAbsolute) {
-            if(SP.getBoolean(R.string.key_danar_visualizeextendedaspercentage, false)){
+            if(SP.getBoolean(R.string.key_danar_visualizeextendedaspercentage, false) && SP.getBoolean(R.string.key_danar_useextended, false)){
                 Profile profile = MainApp.getConfigBuilder().getProfile();
                 if(profile != null) {
                     double basal = profile.getBasal(System.currentTimeMillis());

--- a/app/src/main/java/info/nightscout/androidaps/db/TemporaryBasal.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/TemporaryBasal.java
@@ -10,6 +10,7 @@ import java.util.Date;
 import java.util.Objects;
 
 import info.nightscout.androidaps.MainApp;
+import info.nightscout.androidaps.R;
 import info.nightscout.androidaps.data.Iob;
 import info.nightscout.androidaps.data.IobTotal;
 import info.nightscout.androidaps.data.Profile;
@@ -18,6 +19,7 @@ import info.nightscout.androidaps.interfaces.Interval;
 import info.nightscout.androidaps.plugins.ConfigBuilder.ConfigBuilderPlugin;
 import info.nightscout.utils.DateUtil;
 import info.nightscout.utils.DecimalFormatter;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 21.05.2017.
@@ -271,6 +273,15 @@ public class TemporaryBasal implements Interval {
 
     public String toStringShort() {
         if (isAbsolute) {
+            if(SP.getBoolean(R.string.key_danar_visualizeextendedaspercentage, false)){
+                Profile profile = MainApp.getConfigBuilder().getProfile();
+                if(profile != null) {
+                    double basal = profile.getBasal(System.currentTimeMillis());
+                    if(basal != 0){
+                        return Math.round(absoluteRate*100d/basal) + "% ";
+                    }
+                }
+            }
             return DecimalFormatter.to2Decimal(absoluteRate) + "U/h ";
         } else { // percent
             return percentRate + "% ";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -532,6 +532,7 @@
     <string name="key_danar_bt_name" translatable="false">danar_bt_name</string>
     <string name="key_danar_password" translatable="false">danar_password</string>
     <string name="key_danar_useextended" translatable="false">danar_useextended</string>
+    <string name="key_danar_visualizeextendedaspercentage" translatable="false">danar_visualizeextendedaspercentage"</string>
     <string name="key_danarprofile_dia" translatable="false">danarprofile_dia</string>
     <string name="clearlog">Clear log</string>
     <string name="key_nsclientinternal_autoscroll" translatable="false">nsclientinternal_autoscroll</string>
@@ -650,4 +651,5 @@
     <string name="openaps">OpenAPS</string>
     <string name="device">Device</string>
     <string name="uploader">Uploader</string>
+    <string name="danar_visualizeextendedaspercentage_title">Visualize extended bolus as %</string>
 </resources>

--- a/app/src/main/res/xml/pref_danar.xml
+++ b/app/src/main/res/xml/pref_danar.xml
@@ -17,6 +17,11 @@
             android:defaultValue="false"
             android:key="@string/key_danar_useextended"
             android:title="@string/danar_useextended_title" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:dependency="@string/key_danar_useextended"
+            android:key="@string/key_danar_visualizeextendedaspercentage"
+            android:title="@string/danar_visualizeextendedaspercentage_title" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
A setting that depends on "Use extended boluses for >200%" and visualizes temp basal emulations with extended boluses as %age:

If enabled:
 * Shows cancel-button in overview as %age
 * Shows rate on watchface as %age
 * Keeps the long status in overview as it is so it is still visible what the pump is actually doing

![http://up.picr.de/29630947xo.png](http://up.picr.de/29630947xo.png)

