### PR TITLE
Update strings.xml

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -677,4 +677,6 @@
     <string name="lock_screen">Lock screen</string>
     <string name="lock_screen_short">Lock</string>
     <string name="sensitivity_warning">By turning on Autosense feature remember to enter all eated carbs. Otherwise carbs deviations will be identified wrong as sensitivity change !!</string>
+    <string name="mdtp_ok">OK</string>
+    <string name="mdtp_cancel">Cancel</string>
 </resources>


### PR DESCRIPTION
Adding OK & Cancel to strings.xml solves an error that seems to happen on some phones and causes the OK & Cancel buttons to show weird symbols when english is selected as a language.
![screenshot_20170706-213512](https://user-images.githubusercontent.com/29184757/27936295-4ab8c130-62b0-11e7-98de-3f1f7d3026d0.png)
