### PR TITLE
Align OpenAS(A)MA fragments with layout of other fragments.

### DIFF
--- a/app/src/main/res/layout/loop_fragment.xml
+++ b/app/src/main/res/layout/loop_fragment.xml
@@ -5,7 +5,6 @@
     tools:context="info.nightscout.androidaps.plugins.Loop.LoopFragment">
 
     <ScrollView
-        android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/openapsama_fragment.xml
+++ b/app/src/main/res/layout/openapsama_fragment.xml
@@ -6,12 +6,11 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp">
+        android:layout_height="match_parent">
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <LinearLayout

--- a/app/src/main/res/layout/openapsma_fragment.xml
+++ b/app/src/main/res/layout/openapsma_fragment.xml
@@ -6,12 +6,11 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp">
+        android:layout_height="match_parent">
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <LinearLayout


### PR DESCRIPTION
Removes a margin that makes the top elements jump up and
down when flipping through tabs.