### PR TITLE
NSClient quickfix

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAckAlarm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAckAlarm.java
@@ -29,9 +29,13 @@ public class BroadcastAckAlarm {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
+        try {
+            List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
+            log.debug("ACKALARM " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
 
-        log.debug("ACKALARM " + x.size() + " receivers");
     }
 
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAckAlarm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAckAlarm.java
@@ -31,13 +31,6 @@ public class BroadcastAckAlarm {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-            List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-            log.debug("ACKALARM " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
-
     }
 
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAckAlarm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAckAlarm.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import info.nightscout.androidaps.Services.Intents;
 import info.nightscout.androidaps.plugins.NSClientInternal.data.NSAlarm;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 11.06.2017.
@@ -21,6 +22,7 @@ public class BroadcastAckAlarm {
     private static Logger log = LoggerFactory.getLogger(BroadcastAckAlarm.class);
 
     public static void handleClearAlarm(NSAlarm originalAlarm, Context context, long silenceTimeInMsec) {
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
         Bundle bundle = new Bundle();
         bundle.putInt("level", originalAlarm.getLevel());
         bundle.putString("group", originalAlarm.getGroup());

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAlarm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAlarm.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import info.nightscout.androidaps.Services.Intents;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 26.06.2016.
@@ -20,6 +21,9 @@ public class BroadcastAlarm {
     private static Logger log = LoggerFactory.getLogger(BroadcastAlarm.class);
 
     public static void handleAlarm(JSONObject alarm, Context context) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         bundle.putString("data", alarm.toString());
         Intent intent = new Intent(Intents.ACTION_ALARM);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAlarm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAlarm.java
@@ -30,13 +30,5 @@ public class BroadcastAlarm {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-
-        try{
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("ALARM " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAlarm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAlarm.java
@@ -26,8 +26,13 @@ public class BroadcastAlarm {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+
+        try{
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("ALARM " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAnnouncement.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAnnouncement.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import info.nightscout.androidaps.Services.Intents;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 26.06.2016.
@@ -21,6 +22,9 @@ public class BroadcastAnnouncement {
     private static Logger log = LoggerFactory.getLogger(BroadcastAnnouncement.class);
 
     public static void handleAnnouncement(JSONObject announcement, Context context) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         bundle.putString("data", announcement.toString());
         Intent intent = new Intent(Intents.ACTION_ANNOUNCEMENT);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAnnouncement.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAnnouncement.java
@@ -31,12 +31,5 @@ public class BroadcastAnnouncement {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("ANNOUNCEMENT " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAnnouncement.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastAnnouncement.java
@@ -27,8 +27,12 @@ public class BroadcastAnnouncement {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("ANNOUNCEMENT " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastCals.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastCals.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import info.nightscout.androidaps.Services.Intents;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 26.06.2016.
@@ -20,6 +21,9 @@ public class BroadcastCals {
     private static Logger log = LoggerFactory.getLogger(BroadcastCals.class);
 
     public static void handleNewCal(JSONArray cals, Context context, boolean isDelta) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         bundle.putString("cals", cals.toString());
         bundle.putBoolean("delta", isDelta);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastCals.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastCals.java
@@ -27,8 +27,12 @@ public class BroadcastCals {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("CAL " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastCals.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastCals.java
@@ -31,12 +31,5 @@ public class BroadcastCals {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("CAL " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastClearAlarm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastClearAlarm.java
@@ -30,12 +30,5 @@ public class BroadcastClearAlarm {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("CLEARALARM " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastClearAlarm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastClearAlarm.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import info.nightscout.androidaps.Services.Intents;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 26.06.2016.
@@ -20,6 +21,9 @@ public class BroadcastClearAlarm {
     private static Logger log = LoggerFactory.getLogger(BroadcastClearAlarm.class);
 
     public static void handleClearAlarm(JSONObject clearalarm, Context context) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         bundle.putString("data", clearalarm.toString());
         Intent intent = new Intent(Intents.ACTION_CLEAR_ALARM);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastClearAlarm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastClearAlarm.java
@@ -26,8 +26,12 @@ public class BroadcastClearAlarm {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("CLEARALARM " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastDeviceStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastDeviceStatus.java
@@ -27,13 +27,6 @@ public class BroadcastDeviceStatus {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("DEVICESTATUS " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
     public static void handleNewDeviceStatus(JSONArray statuses, Context context, boolean isDelta) {
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastDeviceStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastDeviceStatus.java
@@ -50,13 +50,6 @@ public class BroadcastDeviceStatus {
             intent.putExtras(bundle);
             intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
             context.sendBroadcast(intent);
-            try {
-            List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-            log.debug("DEVICESTATUS " + part.length() + " records " + x.size() + " receivers");
-            } catch (Exception e){
-                //for testing
-            }
         }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastDeviceStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastDeviceStatus.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import info.nightscout.androidaps.Services.Intents;
+import info.nightscout.utils.SP;
 
 
 public class BroadcastDeviceStatus {
@@ -35,6 +36,11 @@ public class BroadcastDeviceStatus {
         }
     }
     public static void handleNewDeviceStatus(JSONArray statuses, Context context, boolean isDelta) {
+
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
+
         List<JSONArray> splitted = BroadcastTreatment.splitArray(statuses);
         for (JSONArray part: splitted) {
             Bundle bundle = new Bundle();

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastDeviceStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastDeviceStatus.java
@@ -26,9 +26,13 @@ public class BroadcastDeviceStatus {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("DEVICESTATUS " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
     public static void handleNewDeviceStatus(JSONArray statuses, Context context, boolean isDelta) {
         List<JSONArray> splitted = BroadcastTreatment.splitArray(statuses);
@@ -40,9 +44,13 @@ public class BroadcastDeviceStatus {
             intent.putExtras(bundle);
             intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
             context.sendBroadcast(intent);
+            try {
             List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
             log.debug("DEVICESTATUS " + part.length() + " records " + x.size() + " receivers");
+            } catch (Exception e){
+                //for testing
+            }
         }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastMbgs.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastMbgs.java
@@ -27,8 +27,12 @@ public class BroadcastMbgs {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("MBG " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastMbgs.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastMbgs.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import info.nightscout.androidaps.Services.Intents;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 26.06.2016.
@@ -20,6 +21,9 @@ public class BroadcastMbgs {
     private static Logger log = LoggerFactory.getLogger(BroadcastMbgs.class);
 
     public static void handleNewMbg(JSONArray mbgs, Context context, boolean isDelta) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         bundle.putString("mbgs", mbgs.toString());
         bundle.putBoolean("delta", isDelta);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastMbgs.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastMbgs.java
@@ -31,12 +31,5 @@ public class BroadcastMbgs {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("MBG " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastProfile.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastProfile.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import info.nightscout.androidaps.Services.Intents;
 import info.nightscout.androidaps.data.ProfileStore;
+import info.nightscout.utils.SP;
 
 
 /**
@@ -21,6 +22,9 @@ public class BroadcastProfile {
     private static Logger log = LoggerFactory.getLogger(BroadcastProfile.class);
 
     public static void handleNewTreatment(ProfileStore profile, Context context, boolean isDelta) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         bundle.putString("profile", profile.getData().toString());
         bundle.putBoolean("delta", isDelta);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastProfile.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastProfile.java
@@ -32,13 +32,6 @@ public class BroadcastProfile {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("PROFILE " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastProfile.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastProfile.java
@@ -28,9 +28,13 @@ public class BroadcastProfile {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("PROFILE " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
 
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastQueueStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastQueueStatus.java
@@ -6,12 +6,16 @@ import android.os.Bundle;
 import android.os.PowerManager;
 
 import info.nightscout.androidaps.Services.Intents;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 28.02.2016.
  */
 public class BroadcastQueueStatus {
     public static void handleNewStatus(int size, Context context) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
         PowerManager.WakeLock wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,
                 "sendQueue");

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastSgvs.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastSgvs.java
@@ -49,13 +49,6 @@ public class BroadcastSgvs {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("SGV " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastSgvs.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastSgvs.java
@@ -28,9 +28,13 @@ public class BroadcastSgvs {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("SGV " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
 
     public static void handleNewSgv(JSONArray sgvs, Context context, boolean isDelta) {
@@ -41,9 +45,13 @@ public class BroadcastSgvs {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("SGV " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
 
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastSgvs.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastSgvs.java
@@ -32,13 +32,6 @@ public class BroadcastSgvs {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("SGV " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 
     public static void handleNewSgv(JSONArray sgvs, Context context, boolean isDelta) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastSgvs.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastSgvs.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import info.nightscout.androidaps.Services.Intents;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 22.02.2016.
@@ -21,6 +22,9 @@ public class BroadcastSgvs {
     private static Logger log = LoggerFactory.getLogger(BroadcastSgvs.class);
 
     public static void handleNewSgv(JSONObject sgv, Context context, boolean isDelta) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         bundle.putString("sgv", sgv.toString());
         bundle.putBoolean("delta", isDelta);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastStatus.java
@@ -15,6 +15,7 @@ import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.Services.Intents;
 import info.nightscout.androidaps.plugins.NSClientInternal.data.NSSettingsStatus;
 import info.nightscout.androidaps.plugins.NSClientInternal.services.NSClientService;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 24.02.2016.
@@ -23,6 +24,9 @@ public class BroadcastStatus {
     private static Logger log = LoggerFactory.getLogger(BroadcastStatus.class);
 
     public static void handleNewStatus(NSSettingsStatus status, Context context, boolean isDelta) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         try {
             bundle.putString("nsclientversionname", MainApp.instance().getPackageManager().getPackageInfo(MainApp.instance().getPackageName(), 0).versionName);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastStatus.java
@@ -42,12 +42,5 @@ public class BroadcastStatus {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("STATUS: " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastStatus.java
@@ -38,8 +38,12 @@ public class BroadcastStatus {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("STATUS: " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
@@ -36,13 +36,6 @@ public class BroadcastTreatment {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("TREAT_ADD " + treatment.getEventType() + " " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 
     public static void handleNewTreatment(JSONArray treatments, Context context, boolean isDelta) {
@@ -58,13 +51,6 @@ public class BroadcastTreatment {
             intent.putExtras(bundle);
             intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
             context.sendBroadcast(intent);
-            try {
-                List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-                log.debug("TREAT_ADD " + part.length() + " " + x.size() + " receivers");
-            } catch (Exception e){
-            //for testing
-        }
-
         }
     }
 
@@ -79,12 +65,6 @@ public class BroadcastTreatment {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-            log.debug("TREAT_CHANGE " + treatment.getString("_id") + " " + x.size() + " receivers");
-        } catch (Exception e) {
-        }
     }
 
     public static void handleChangedTreatment(JSONArray treatments, Context context, boolean isDelta) {
@@ -100,13 +80,6 @@ public class BroadcastTreatment {
             intent.putExtras(bundle);
             intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
             context.sendBroadcast(intent);
-            try {
-            List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-            log.debug("TREAT_CHANGE " + part.length() + " " + x.size() + " receivers");
-            } catch (Exception e){
-                //for testing
-            }
         }
     }
 
@@ -121,14 +94,6 @@ public class BroadcastTreatment {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-
-            log.debug("TREAT_REMOVE " + treatment.getString("_id") + " " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 
     public static void handleRemovedTreatment(JSONArray treatments, Context context, boolean isDelta) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
 import android.os.Bundle;
+import android.os.TransactionTooLargeException;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -46,9 +47,17 @@ public class BroadcastTreatment {
             intent.putExtras(bundle);
             intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
             context.sendBroadcast(intent);
-            List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
+            try {
+                List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
+                log.debug("TREAT_ADD " + part.length() + " " + x.size() + " receivers");
+            } catch (RuntimeException exception){
+                if(exception.getCause() instanceof TransactionTooLargeException){
+                    log.error("TREAT_ADD " + part.length() + " ERROR: no receiver size, CAUSE: " + exception.getMessage());
+                } else {
+                    throw exception;
+                }
+            }
 
-            log.debug("TREAT_ADD " + part.length() + " " + x.size() + " receivers");
         }
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
@@ -32,9 +32,13 @@ public class BroadcastTreatment {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("TREAT_ADD " + treatment.getEventType() + " " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
 
     public static void handleNewTreatment(JSONArray treatments, Context context, boolean isDelta) {
@@ -50,9 +54,9 @@ public class BroadcastTreatment {
             try {
                 List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
                 log.debug("TREAT_ADD " + part.length() + " " + x.size() + " receivers");
-            } catch (Throwable exception){
-                    log.debug("TREAT_ADD " + part.length() + " ERROR: no receiver size, CAUSE: " + exception.getMessage());
-            }
+            } catch (Exception e){
+            //for testing
+        }
 
         }
     }
@@ -65,11 +69,11 @@ public class BroadcastTreatment {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
-        try {
             log.debug("TREAT_CHANGE " + treatment.getString("_id") + " " + x.size() + " receivers");
-        } catch (JSONException e) {
+        } catch (Exception e) {
         }
     }
 
@@ -83,9 +87,13 @@ public class BroadcastTreatment {
             intent.putExtras(bundle);
             intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
             context.sendBroadcast(intent);
+            try {
             List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
             log.debug("TREAT_CHANGE " + part.length() + " " + x.size() + " receivers");
+            } catch (Exception e){
+                //for testing
+            }
         }
     }
 
@@ -97,11 +105,13 @@ public class BroadcastTreatment {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
-        try {
+
             log.debug("TREAT_REMOVE " + treatment.getString("_id") + " " + x.size() + " receivers");
-        } catch (JSONException e) {
+        } catch (Exception e){
+            //for testing
         }
     }
 
@@ -113,9 +123,13 @@ public class BroadcastTreatment {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("TREAT_REMOVE " + treatments.length() + " treatments " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
 
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
@@ -50,12 +50,8 @@ public class BroadcastTreatment {
             try {
                 List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
                 log.debug("TREAT_ADD " + part.length() + " " + x.size() + " receivers");
-            } catch (RuntimeException exception){
-                if(exception.getCause() instanceof TransactionTooLargeException){
-                    log.error("TREAT_ADD " + part.length() + " ERROR: no receiver size, CAUSE: " + exception.getMessage());
-                } else {
-                    throw exception;
-                }
+            } catch (Throwable exception){
+                    log.debug("TREAT_ADD " + part.length() + " ERROR: no receiver size, CAUSE: " + exception.getMessage());
             }
 
         }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import info.nightscout.androidaps.Services.Intents;
 import info.nightscout.androidaps.plugins.NSClientInternal.data.NSTreatment;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 20.02.2016.
@@ -25,6 +26,9 @@ public class BroadcastTreatment {
     private static Logger log = LoggerFactory.getLogger(BroadcastTreatment.class);
 
     public static void handleNewTreatment(NSTreatment treatment, Context context, boolean isDelta) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         bundle.putString("treatment", treatment.getData().toString());
         bundle.putBoolean("delta", isDelta);
@@ -42,6 +46,9 @@ public class BroadcastTreatment {
     }
 
     public static void handleNewTreatment(JSONArray treatments, Context context, boolean isDelta) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         List<JSONArray> splitted = splitArray(treatments);
         for (JSONArray part: splitted) {
             Bundle bundle = new Bundle();
@@ -62,6 +69,9 @@ public class BroadcastTreatment {
     }
 
     public void handleChangedTreatment(JSONObject treatment, Context context, boolean isDelta) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         bundle.putString("treatment", treatment.toString());
         bundle.putBoolean("delta", isDelta);
@@ -78,6 +88,9 @@ public class BroadcastTreatment {
     }
 
     public static void handleChangedTreatment(JSONArray treatments, Context context, boolean isDelta) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         List<JSONArray> splitted = splitArray(treatments);
         for (JSONArray part: splitted) {
             Bundle bundle = new Bundle();
@@ -98,6 +111,9 @@ public class BroadcastTreatment {
     }
 
     public static void handleRemovedTreatment(JSONObject treatment, Context context, boolean isDelta) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         bundle.putString("treatment", treatment.toString());
         bundle.putBoolean("delta", isDelta);
@@ -116,6 +132,9 @@ public class BroadcastTreatment {
     }
 
     public static void handleRemovedTreatment(JSONArray treatments, Context context, boolean isDelta) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         bundle.putString("treatments", treatments.toString());
         bundle.putBoolean("delta", isDelta);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
@@ -142,13 +142,6 @@ public class BroadcastTreatment {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("TREAT_REMOVE " + treatments.length() + " treatments " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastUrgentAlarm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastUrgentAlarm.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import info.nightscout.androidaps.Services.Intents;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 26.06.2016.
@@ -20,6 +21,9 @@ public class BroadcastUrgentAlarm {
     private static Logger log = LoggerFactory.getLogger(BroadcastUrgentAlarm.class);
 
     public static void handleUrgentAlarm(JSONObject urgentalarm, Context context) {
+
+        if(!SP.getBoolean("nsclient_localbroadcasts", true)) return;
+
         Bundle bundle = new Bundle();
         bundle.putString("data", urgentalarm.toString());
         Intent intent = new Intent(Intents.ACTION_URGENT_ALARM);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastUrgentAlarm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastUrgentAlarm.java
@@ -26,8 +26,12 @@ public class BroadcastUrgentAlarm {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
+        try {
         List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
 
         log.debug("URGENTALARM " + x.size() + " receivers");
+        } catch (Exception e){
+            //for testing
+        }
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastUrgentAlarm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastUrgentAlarm.java
@@ -30,12 +30,5 @@ public class BroadcastUrgentAlarm {
         intent.putExtras(bundle);
         intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         context.sendBroadcast(intent);
-        try {
-        List<ResolveInfo> x = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-
-        log.debug("URGENTALARM " + x.size() + " receivers");
-        } catch (Exception e){
-            //for testing
-        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -580,6 +580,7 @@
     <string name="superbolus">Superbolus</string>
     <string name="ns_logappstartedevent">Log app start to NS</string>
     <string name="key_ns_logappstartedevent" translatable="false">ns_logappstartedevent</string>
+    <string name="key_ns_localbroadcasts" translatable="false">nsclient_localbroadcasts</string>
     <string name="restartingapp">Exiting application to apply settings.</string>
     <string name="danarv2pump">DanaRv2</string>
     <string name="configbuilder_insulin">Insulin</string>
@@ -685,4 +686,5 @@
     <string name="cpp_valuesnotstored">Values not stored!</string>
     <string name="wear_overviewnotifications">Overview Notifications</string>
     <string name="wear_overviewnotifications_summary">Pass the Overview Notifications through as wear confirmation messages.</string>
+    <string name="ns_localbroadcasts">Enable loacal broadcasts to other apps (like xDrip).</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -687,4 +687,5 @@
     <string name="wear_overviewnotifications">Overview Notifications</string>
     <string name="wear_overviewnotifications_summary">Pass the Overview Notifications through as wear confirmation messages.</string>
     <string name="ns_localbroadcasts">Enable loacal broadcasts to other apps (like xDrip).</string>
+    <string name="ns_localbroadcasts_title">Enable local Broadcasts.</string>
 </resources>

--- a/app/src/main/res/xml/pref_nsclientinternal.xml
+++ b/app/src/main/res/xml/pref_nsclientinternal.xml
@@ -30,7 +30,9 @@
         <SwitchPreference
             android:defaultValue="true"
             android:key="@string/key_ns_localbroadcasts"
-            android:title="@string/ns_localbroadcasts" />
+            android:title="@string/ns_localbroadcasts_title"
+            android:summary="@string/ns_localbroadcasts"/>
+
 
         <PreferenceScreen android:title="@string/ns_alarmoptions">
 

--- a/app/src/main/res/xml/pref_nsclientinternal.xml
+++ b/app/src/main/res/xml/pref_nsclientinternal.xml
@@ -27,6 +27,11 @@
             android:key="@string/key_ns_logappstartedevent"
             android:title="@string/ns_logappstartedevent" />
 
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/key_ns_localbroadcasts"
+            android:title="@string/ns_localbroadcasts" />
+
         <PreferenceScreen android:title="@string/ns_alarmoptions">
 
             <SwitchPreference


### PR DESCRIPTION
 * Removes some debug output that stresses the broadcast system.
 * Setting that allows the user to not send broadcasts to other apps. Most AAPS-Users deactivate the reception of broadcasts in xDrip anyways. Not sending them will cause less load on the system.