### PR TITLE
change logfile name pattern

### DIFF
--- a/app/src/main/assets/logback.xml
+++ b/app/src/main/assets/logback.xml
@@ -6,7 +6,7 @@
 	<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover. Make sure the path matches the one in the file element or else
              the rollover logs are placed in the working directory. -->
-            <fileNamePattern>${EXT_FILES_DIR}/AndroidAPS._%d{yyyy-MM-dd}.%i.zip</fileNamePattern>
+            <fileNamePattern>${EXT_FILES_DIR}/AndroidAPS._%d{yyyy-MM-dd}_%d{HH-mm-ss, aux}_.%i.zip</fileNamePattern>
 
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>5MB</maxFileSize>


### PR DESCRIPTION
change logfile name pattern to still be rotated once a day but include the hour-minute-seconds as timestamp in the filename