### PR TITLE
Logging: Print filename and line instead of logger name.

### DIFF
--- a/app/src/main/assets/logback.xml
+++ b/app/src/main/assets/logback.xml
@@ -15,7 +15,7 @@
             <maxHistory>120</maxHistory>
 	</rollingPolicy>
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level [%file:%line]: %msg%n</pattern>
     </encoder>
   </appender>
 
@@ -24,7 +24,7 @@
 		  <pattern>%logger{0}</pattern>
 	  </tagEncoder>
     <encoder>
-      <pattern>[%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>[%thread] %-5level [%file:%line]: %msg%n</pattern>
     </encoder>
   </appender>
   


### PR DESCRIPTION
This replaces the logger name (fully qualified) with the class name (simple name) and line numbers. Output looks like this afterwards:
```
11:44:54.089 [main] DEBUG [DanaRExecutionService.java:112]: Device has disconnected SpiritCombo
11:44:54.106 [main] DEBUG [DanaRKoreanExecutionService.java:108]: Device has disconnected SpiritCombo
11:44:54.110 [main] DEBUG [DanaRv2ExecutionService.java:82]: Device has disconnected SpiritCombo
```
