### PR TITLE
Restrict DIA for expectedDelta

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
@@ -208,7 +208,7 @@ public class DetermineBasalAdapterAMAJS {
 
         mProfile = new V8Object(mV8rt);
         mProfile.add("max_iob", maxIob);
-        mProfile.add("dia", profile.getDia());
+        mProfile.add("dia", Math.min(profile.getDia(), 3d));
         mProfile.add("type", "current");
         mProfile.add("max_daily_basal", profile.getMaxDailyBasal());
         mProfile.add("max_basal", maxBasal);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSMA/DetermineBasalAdapterMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSMA/DetermineBasalAdapterMAJS.java
@@ -231,7 +231,7 @@ public class DetermineBasalAdapterMAJS {
         String units = profile.getUnits();
 
         mProfile.add("max_iob", maxIob);
-        mProfile.add("dia", profile.getDia());
+        mProfile.add("dia", Math.min(profile.getDia(), 3d));
         mProfile.add("type", "current");
         mProfile.add("max_daily_basal", profile.getMaxDailyBasal());
         mProfile.add("max_basal", maxBasal);


### PR DESCRIPTION
In order to make the new insulin profiles that need a longer DIA compatible with the classic determine-basal versions, restrict the DIA to the old default of 3 hours.

WIP: only tested for a few loop cycles.