### PR TITLE
Show profile switch button in profiles

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/ProfileCircadianPercentage/CircadianPercentageProfileFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/ProfileCircadianPercentage/CircadianPercentageProfileFragment.java
@@ -500,9 +500,13 @@ public class CircadianPercentageProfileFragment extends SubscriberFragment {
             activity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    if (!MainApp.getConfigBuilder().isInitialized() || MainApp.getConfigBuilder().isSuspended() || !MainApp.getConfigBuilder().getPumpDescription().isSetBasalProfileCapable) {
+                    if (!MainApp.getConfigBuilder().isInitialized() || MainApp.getConfigBuilder().isSuspended()) {
                         profileswitchButton.setVisibility(View.GONE);
+                    } else if (!MainApp.getConfigBuilder().getPumpDescription().isSetBasalProfileCapable) {
+                        profileswitchButton.setText(MainApp.instance().getText(R.string.activate_profile));
+                        profileswitchButton.setVisibility(View.VISIBLE);
                     } else {
+                        profileswitchButton.setText(MainApp.instance().getText(R.string.send_to_pump));
                         profileswitchButton.setVisibility(View.VISIBLE);
                     }
                 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/ProfileLocal/LocalProfileFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/ProfileLocal/LocalProfileFragment.java
@@ -148,9 +148,13 @@ public class LocalProfileFragment extends SubscriberFragment {
             activity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    if (!MainApp.getConfigBuilder().isInitialized() || MainApp.getConfigBuilder().isSuspended() || !MainApp.getConfigBuilder().getPumpDescription().isSetBasalProfileCapable) {
+                    if (!MainApp.getConfigBuilder().isInitialized() || MainApp.getConfigBuilder().isSuspended()) {
                         profileswitchButton.setVisibility(View.GONE);
+                    } else if (!MainApp.getConfigBuilder().getPumpDescription().isSetBasalProfileCapable) {
+                        profileswitchButton.setText(MainApp.instance().getText(R.string.activate_profile));
+                        profileswitchButton.setVisibility(View.VISIBLE);
                     } else {
+                        profileswitchButton.setText(MainApp.instance().getText(R.string.send_to_pump));
                         profileswitchButton.setVisibility(View.VISIBLE);
                     }
                 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/ProfileSimple/SimpleProfileFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/ProfileSimple/SimpleProfileFragment.java
@@ -156,9 +156,13 @@ public class SimpleProfileFragment extends SubscriberFragment {
             activity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    if (!MainApp.getConfigBuilder().isInitialized() || MainApp.getConfigBuilder().isSuspended() || !MainApp.getConfigBuilder().getPumpDescription().isSetBasalProfileCapable) {
+                    if (!MainApp.getConfigBuilder().isInitialized() || MainApp.getConfigBuilder().isSuspended()) {
                         profileswitchButton.setVisibility(View.GONE);
+                    } else if (!MainApp.getConfigBuilder().getPumpDescription().isSetBasalProfileCapable) {
+                        profileswitchButton.setText(MainApp.instance().getText(R.string.activate_profile));
+                        profileswitchButton.setVisibility(View.VISIBLE);
                     } else {
+                        profileswitchButton.setText(MainApp.instance().getText(R.string.send_to_pump));
                         profileswitchButton.setVisibility(View.VISIBLE);
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -698,8 +698,7 @@
     <string name="rapid_acting_oref">Rapid-Acting Oref</string>
     <string name="ultrarapid_oref">Ultra-Rapid Oref</string>
     <string name="dia_too_short" formatted="false">"DIA of %s too short - using %s instead!"</string>
-
-
+    <string name="activate_profile">ACTIVATE PROFILE</string>
 
 
 </resources>


### PR DESCRIPTION
Shows the button to trigger a profile switch button in the profile fragments even when the pump basal cannot be written.
Instead of "SEND TO PUMP" it will then show "ACTIVATE PROFILE".

This has become necessary with the interval logic that needs profile switch events to happen in order to accept a new profile.