### PR TITLE
Only warn about invalid DIA if coming from an active insulin plugin.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/InsulinOrefCurves/InsulinOrefBasePlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/InsulinOrefCurves/InsulinOrefBasePlugin.java
@@ -18,6 +18,9 @@ public abstract class InsulinOrefBasePlugin implements PluginBase, InsulinInterf
 
     public static double MIN_DIA = 5;
 
+    protected static boolean fragmentEnabled = false;
+    protected static boolean fragmentVisible = false;
+
     long lastWarned = 0;
 
     @Override
@@ -51,7 +54,7 @@ public abstract class InsulinOrefBasePlugin implements PluginBase, InsulinInterf
         if(dia >= MIN_DIA){
             return dia;
         } else {
-            if((System.currentTimeMillis() - lastWarned) > 60*1000) {
+            if(fragmentEnabled && (System.currentTimeMillis() - lastWarned) > 60*1000) {
                 lastWarned = System.currentTimeMillis();
                 Notification notification = new Notification(Notification.SHORT_DIA, String.format(MainApp.sResources.getString(R.string.dia_too_short), dia, MIN_DIA), Notification.URGENT);
                 MainApp.bus().post(new EventNewNotification(notification));

--- a/app/src/main/java/info/nightscout/androidaps/plugins/InsulinOrefCurves/InsulinOrefFreePeakPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/InsulinOrefCurves/InsulinOrefFreePeakPlugin.java
@@ -10,9 +10,6 @@ import info.nightscout.utils.SP;
 
 public class InsulinOrefFreePeakPlugin extends InsulinOrefBasePlugin {
 
-    private static boolean fragmentEnabled = false;
-    private static boolean fragmentVisible = false;
-
     public static final int DEFAULT_PEAK = 75;
 
     @Override

--- a/app/src/main/java/info/nightscout/androidaps/plugins/InsulinOrefCurves/InsulinOrefRapidActingPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/InsulinOrefCurves/InsulinOrefRapidActingPlugin.java
@@ -9,9 +9,6 @@ import info.nightscout.androidaps.R;
 
 public class InsulinOrefRapidActingPlugin extends InsulinOrefBasePlugin {
 
-    private static boolean fragmentEnabled = false;
-    private static boolean fragmentVisible = false;
-
     public static final int PEAK = 75;
 
     @Override

--- a/app/src/main/java/info/nightscout/androidaps/plugins/InsulinOrefCurves/InsulinOrefUltraRapidActingPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/InsulinOrefCurves/InsulinOrefUltraRapidActingPlugin.java
@@ -9,9 +9,6 @@ import info.nightscout.androidaps.R;
 
 public class InsulinOrefUltraRapidActingPlugin extends InsulinOrefBasePlugin {
 
-    private static boolean fragmentEnabled = false;
-    private static boolean fragmentVisible = false;
-
     public static final int PEAK = 55;
 
     @Override


### PR DESCRIPTION
Since the id of the insulin plugin used is saved with each treatment record,
calculating IOB will ask such a plugin. If another insulin plugin is active now,
this would still raise an error about a too short DIA, which is confusing at best.
This change only displays this warning if the plugin is enabled.

@AdrianLxM 