### PR TITLE
Dia divisor / bolussnooze fix

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/db/Treatment.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/Treatment.java
@@ -183,10 +183,8 @@ public class Treatment implements DataPointWithLabelInterface {
     public Iob iobCalc(long time, double dia) {
         if (!isValid)
             return new Iob();
-        InsulinInterface insulinInterface = MainApp.getInsulinIterfaceById(insulinInterfaceID);
-        if (insulinInterface == null)
-            insulinInterface = ConfigBuilderPlugin.getActiveInsulin();
 
+        InsulinInterface insulinInterface = ConfigBuilderPlugin.getActiveInsulin();
         return insulinInterface.iobCalcForTreatment(this, time, dia);
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/TreatmentsPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/TreatmentsPlugin.java
@@ -187,8 +187,8 @@ public class TreatmentsPlugin implements PluginBase, TreatmentsInterface {
             if (!t.isSMB) {
                 // instead of dividing the DIA that only worked on the bilinear curves,
                 // multiply the time the treatment is seen active.
-                long timeSinceTreatent = t.date - time;
-                long snoozeTime = t.date - (long)(timeSinceTreatent * SP.getDouble("openapsama_bolussnooze_dia_divisor", 2.0));
+                long timeSinceTreatment =  time - t.date;
+                long snoozeTime = t.date + (long)(timeSinceTreatment * SP.getDouble("openapsama_bolussnooze_dia_divisor", 2.0));
                 Iob bIOB = t.iobCalc(snoozeTime, dia);
                 total.bolussnooze += bIOB.iobContrib;
             } else {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/TreatmentsPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/TreatmentsPlugin.java
@@ -185,7 +185,11 @@ public class TreatmentsPlugin implements PluginBase, TreatmentsInterface {
             total.iob += tIOB.iobContrib;
             total.activity += tIOB.activityContrib;
             if (!t.isSMB) {
-                Iob bIOB = t.iobCalc(time, dia / SP.getDouble("openapsama_bolussnooze_dia_divisor", 2.0));
+                // instead of dividing the DIA that only worked on the bilinear curves,
+                // multiply the time the treatment is seen active.
+                long timeSinceTreatent = t.date - time;
+                long snoozeTime = t.date - (long)(timeSinceTreatent * SP.getDouble("openapsama_bolussnooze_dia_divisor", 2.0));
+                Iob bIOB = t.iobCalc(snoozeTime, dia);
                 total.bolussnooze += bIOB.iobContrib;
             } else {
                 total.basaliob += t.insulin;


### PR DESCRIPTION
This should fix the issues we have around the dia divisor and bolus snooze.

It fixes Issue https://github.com/MilosKozak/AndroidAPS/issues/376
The idea behind the "dia divisor" was that the time for the bolussnooze passes faster for a treatment than for IOB to decay the bolussnooze faster. With the bilinear curves this was done by dividing the DIA what no longer can be done with the new curves. Therefore the new implementation uses the same DIA but actually lets the time pass faster.
This is the same way of implementing it as in OpeAPS-Oref0/1:
https://github.com/openaps/oref0/pull/568/files#diff-b43ed8995d69a77e23443ef00bb36bb8R140


It should also fix the issue of "old" plugins being used with the state (dia, peak, ...) of the new ones, leading to "alarms from the past" and that the user did have no appropriate feedback on parameter change - as described in https://github.com/MilosKozak/AndroidAPS/pull/377