### PR TITLE
Fill treatments in Overview

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/db/Treatment.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/Treatment.java
@@ -8,8 +8,6 @@ import com.j256.ormlite.table.DatabaseTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Date;
-import java.util.List;
 import java.util.Objects;
 
 import info.nightscout.androidaps.Constants;
@@ -17,7 +15,6 @@ import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.data.Iob;
 import info.nightscout.androidaps.interfaces.InsulinInterface;
 import info.nightscout.androidaps.plugins.ConfigBuilder.ConfigBuilderPlugin;
-import info.nightscout.androidaps.data.Profile;
 import info.nightscout.androidaps.plugins.Overview.graphExtensions.DataPointWithLabelInterface;
 import info.nightscout.androidaps.plugins.Overview.graphExtensions.PointsWithLabelGraphSeries;
 import info.nightscout.utils.DateUtil;
@@ -170,7 +167,10 @@ public class Treatment implements DataPointWithLabelInterface {
 
     @Override
     public int getColor() {
-        return Color.CYAN;
+        if (isValid)
+            return Color.CYAN;
+        else
+            return MainApp.instance().getResources().getColor(android.R.color.holo_red_light);
     }
 
     @Override

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Actions/dialogs/FillDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Actions/dialogs/FillDialog.java
@@ -164,7 +164,7 @@ public class FillDialog extends DialogFragment implements OnClickListener {
                                 DetailedBolusInfo detailedBolusInfo = new DetailedBolusInfo();
                                 detailedBolusInfo.insulin = finalInsulinAfterConstraints;
                                 detailedBolusInfo.context = context;
-                                detailedBolusInfo.source = Source.NONE;
+                                detailedBolusInfo.source = Source.USER;
                                 detailedBolusInfo.isValid = false; // do not count it in IOB (for pump history)
                                 PumpEnactResult result = pump.deliverTreatment(detailedBolusInfo);
                                 if (!result.success) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Actions/dialogs/FillDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Actions/dialogs/FillDialog.java
@@ -69,8 +69,8 @@ public class FillDialog extends DialogFragment implements OnClickListener {
 
         insulin = (TextView) view.findViewById(R.id.treatments_newtreatment_insulinamount);
         Double maxInsulin = MainApp.getConfigBuilder().applyBolusConstraints(Constants.bolusOnlyForCheckLimit);
-
-        editInsulin = new PlusMinusEditText(view, R.id.treatments_newtreatment_insulinamount, R.id.treatments_newtreatment_insulinamount_plus, R.id.treatments_newtreatment_insulinamount_minus, 0d, 0d, maxInsulin, 0.05d, new DecimalFormat("0.00"), false);
+        double bolusstep = MainApp.getConfigBuilder().getPumpDescription().bolusStep;
+        editInsulin = new PlusMinusEditText(view, R.id.treatments_newtreatment_insulinamount, R.id.treatments_newtreatment_insulinamount_plus, R.id.treatments_newtreatment_insulinamount_minus, 0d, 0d, maxInsulin, bolusstep, new DecimalFormat("0.00"), false);
 
         //setup preset buttons
         Button button1 = (Button) view.findViewById(R.id.fill_preset_button1);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/OverviewFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/OverviewFragment.java
@@ -1598,8 +1598,6 @@ public class OverviewFragment extends Fragment implements View.OnClickListener, 
 
         for (int tx = 0; tx < treatments.size(); tx++) {
             Treatment t = treatments.get(tx);
-            if (!t.isValid)
-                continue;
             if (t.getX() < fromTime || t.getX() > endTime) continue;
             t.setY(getNearestBg((long) t.getX(), bgReadingsArray));
             filteredTreatments.add(t);


### PR DESCRIPTION
* Fill treatments in the chart Overview - with "invalid" colour.
* Also fixes the bug that fill treatments from the phone won't show up in the history (source was NONE not USER) - watch was working.
* Also sets the granularity of the possible insulin dosage in the fill dialog to `bolusStep`