### PR TITLE
Split treatments into smaller packages before broadcasting

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/broadcasts/BroadcastTreatment.java
@@ -183,7 +183,7 @@ public class BroadcastTreatment {
                         ret.add(newarr);
                     }
                     newarr = new JSONArray();
-                    count = 200;
+                    count = 100;
                 }
                 newarr.put(array.get(i));
                 --count;


### PR DESCRIPTION
With more data per treatment it may now happen that the data in one package will become too large.

```
09-01 13:43:30.938 27281-27281/info.nightscout.androidaps D/DataReceiver: [main] DEBUG [DataReceiver.java:19]: onReceive Intent { act=info.nightscout.client.NEW_SGV flg=0x20 (has extras) }
09-01 13:43:31.418 27281-27281/info.nightscout.androidaps D/DataReceiver: [main] DEBUG [DataReceiver.java:19]: onReceive Intent { act=info.nightscout.client.NEW_TREATMENT flg=0x20 (has extras) }
09-01 13:43:31.659 27281-27281/info.nightscout.androidaps E/AndroidRuntime: FATAL EXCEPTION: main
Process: info.nightscout.androidaps, PID: 27281
java.lang.RuntimeException: android.os.TransactionTooLargeException: data parcel size 1052940 bytes
at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1392)
at android.app.ContextImpl.startService(ContextImpl.java:1358)
at android.content.ContextWrapper.startService(ContextWrapper.java:613)
at android.support.v4.content.WakefulBroadcastReceiver.startWakefulService(WakefulBroadcastReceiver.java:89)
at info.nightscout.androidaps.receivers.DataReceiver.onReceive(DataReceiver.java:20)
at android.support.v4.content.LocalBroadcastManager.executePendingBroadcasts(LocalBroadcastManager.java:297)
at android.support.v4.content.LocalBroadcastManager.access$000(LocalBroadcastManager.java:46)
at android.support.v4.content.LocalBroadcastManager$1.handleMessage(LocalBroadcastManager.java:116)
at android.os.Handler.dispatchMessage(Handler.java:102)
at android.os.Looper.loop(Looper.java:154)
at android.app.ActivityThread.main(ActivityThread.java:6186)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
Caused by: android.os.TransactionTooLargeException: data parcel size 1052940 bytes
at android.os.BinderProxy.transactNative(Native Method)
```

Splitting into smaller packages solved this case.
Thank's @McHoffi for your help debugging this.