### PR TITLE
NDK filters to work around j2v8 vs. libBleCommandUtil issue.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ android {
         buildConfigField "String", "BUILDVERSION", generateGitBuild()
 
         ndk {
+            abiFilters "armeabi-v7a", "x86", "armeabi", "mips"
             moduleName "BleCommandUtil"
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+android.useDeprecatedNdk=true


### PR DESCRIPTION
j2v8 only provides files for x86 and arm-v7a while libBleCommandUtil
provides x64 libs as well. This fails to load since x86 & x64 can't be mixed
and Android ends up loading libBleCommandUtil's x64 variant (on a x64
device) and then failing since there's no x64 version of j2v8.

This excludes all libBleCommandUtil ibs except those that match j2v8.

Revert this when we switch away from j2v8.

(cherry picked from commit 09036dc)