### PR TITLE
NSTreatments NPE fix

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Careportal/Dialogs/NewNSTreatmentDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Careportal/Dialogs/NewNSTreatmentDialog.java
@@ -138,6 +138,7 @@ public class NewNSTreatmentDialog extends DialogFragment implements View.OnClick
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+        if (options==null) return null;
         getDialog().setTitle(getString(options.eventName));
         setStyle(DialogFragment.STYLE_NORMAL, getTheme());
         View view = inflater.inflate(R.layout.careportal_newnstreatment_dialog, container, false);


### PR DESCRIPTION
When the dialog was open and the phone goes to sleep/lock screen, Android may garbage collect and options is no longer available. -> NPE

I think as quick fix it is ok to not show a dialog at all. If the user stopped using the dialog and lets the phone sleep for a longer while with the phone going to sleep... he can open it again, if he wants it.