### PR TITLE
Cancel ongoing notification when plugin is disabled.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Persistentnotification/PersistentNotificationPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Persistentnotification/PersistentNotificationPlugin.java
@@ -95,24 +95,27 @@ public class PersistentNotificationPlugin implements PluginBase {
 
     @Override
     public void setFragmentEnabled(int type, boolean fragmentEnabled) {
-
         if (getType() == type) {
             this.fragmentEnabled = fragmentEnabled;
+            enableDisableNotification(fragmentEnabled);
             checkBusRegistration();
-            //updateNotification();
         }
-
     }
 
-    private void updateNotification() {
-
+    private void enableDisableNotification(boolean fragmentEnabled) {
         if (!fragmentEnabled) {
             NotificationManager mNotificationManager =
                     (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
             mNotificationManager.cancel(ONGOING_NOTIFICATION_ID);
+        } else {
+            updateNotification();
+        }
+    }
+
+    private void updateNotification() {
+        if (!fragmentEnabled) {
             return;
         }
-
 
         String line1 = ctx.getString(R.string.noprofile);
 


### PR DESCRIPTION
Should also fix an issue where the notification isn't shown an startup when bus was registered too late or no values come in, since `updateNotification` is now called when the fragment is enabled on boot.