### PR TITLE
Bluetooth Watchdog

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/Constants.java
+++ b/app/src/main/java/info/nightscout/androidaps/Constants.java
@@ -61,4 +61,5 @@ public class Constants {
 
     // Pump
     public static final int PUMP_MAX_CONNECTION_TIME_IN_SECONDS = 60 - 1;
+    public static final int MIN_WATCHDOG_INTERVAL_IN_SECONDS = 12 * 60;
 }

--- a/app/src/main/java/info/nightscout/androidaps/queue/QueueThread.java
+++ b/app/src/main/java/info/nightscout/androidaps/queue/QueueThread.java
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.queue;
 
+import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
 import android.os.PowerManager;
 import android.os.SystemClock;
@@ -16,6 +17,7 @@ import info.nightscout.androidaps.interfaces.PumpInterface;
 import info.nightscout.androidaps.plugins.ConfigBuilder.ConfigBuilderPlugin;
 import info.nightscout.androidaps.plugins.Overview.events.EventDismissBolusprogressIfRunning;
 import info.nightscout.androidaps.queue.events.EventQueueChanged;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 09.11.2017.
@@ -61,8 +63,27 @@ public class QueueThread extends Thread {
                     MainApp.bus().post(new EventDismissBolusprogressIfRunning(new PumpEnactResult()));
                     MainApp.bus().post(new EventPumpStatusChanged(MainApp.sResources.getString(R.string.connectiontimedout)));
                     pump.stopConnecting();
-                    queue.clear();
-                    return;
+
+                    //BLUETOOTH-WATCHDOG
+                    boolean watchdog = SP.getBoolean(R.string.key_btwatchdog, false);
+                    long last_watchdog = SP.getLong(R.string.key_btwatchdog_lastbark, 0l);
+                    watchdog = watchdog && System.currentTimeMillis() - last_watchdog > (Constants.MIN_WATCHDOG_INTERVAL_IN_SECONDS * 1000);
+                    if(watchdog) {
+                        log.debug("BT watchdog - toggeling the phonest bluetooth");
+                        //write time
+                        SP.putLong(R.string.key_btwatchdog_lastbark, System.currentTimeMillis());
+                        //toggle BT
+                        BluetoothAdapter mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+                        mBluetoothAdapter.disable();
+                        SystemClock.sleep(1000);
+                        mBluetoothAdapter.enable();
+                        SystemClock.sleep(1000);
+                        //start over again once after watchdog barked
+                        connectionStartTime = System.currentTimeMillis();
+                    } else {
+                        queue.clear();
+                        return;
+                    }
                 }
 
                 if (!pump.isConnected()) {

--- a/app/src/main/java/info/nightscout/utils/SP.java
+++ b/app/src/main/java/info/nightscout/utils/SP.java
@@ -65,7 +65,11 @@ public class SP {
     }
 
     static public long getLong(int resourceID, Long defaultValue) {
-        return SafeParse.stringToLong(sharedPreferences.getString(MainApp.sResources.getString(resourceID), defaultValue.toString()));
+        try {
+            return sharedPreferences.getLong(MainApp.sResources.getString(resourceID), defaultValue);
+        } catch (Exception e) {
+            return SafeParse.stringToLong(sharedPreferences.getString(MainApp.sResources.getString(resourceID), defaultValue.toString()));
+        }
     }
 
     static public long getLong(String key, Long defaultValue) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -772,5 +772,10 @@
     <string name="key_missed_bg_readings_threshold" translatable="false">missed_bg_readings_threshold</string>
     <string name="urgent_alarm">Urgent Alarm</string>
     <string name="info">INFO</string>
+    <string name="key_btwatchdog" translatable="false">bt_watchdog</string>
+    <string name="key_btwatchdog_lastbark" translatable="false">bt_watchdog_last</string>
+    <string name="bluetooth">Bluetooth</string>
+    <string name="btwatchdog_title">BT Watchdog</string>
+    <string name="btwatchdog_summary">Switches off the phone\'s bluetooth for one second if no connection to the pump is possible. This may help on some phones where the bluetooth stack freezes.</string>
 </resources>
 

--- a/app/src/main/res/xml/pref_advanced.xml
+++ b/app/src/main/res/xml/pref_advanced.xml
@@ -124,6 +124,16 @@
                     android:title="@string/do_not_track_profile_switch"
                     android:summary="@string/do_not_track_profile_switch_summary"/>
             </PreferenceCategory>
+
+            <PreferenceCategory
+                android:title="@string/bluetooth">
+                <SwitchPreference
+                    android:defaultValue="false"
+                    android:key="@string/key_btwatchdog"
+                    android:title="@string/btwatchdog_title"
+                    android:summary="@string/btwatchdog_summary"/>
+            </PreferenceCategory>
+
         </PreferenceScreen>
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Fixes previously unused utility function `SP.getLong(...)` when called with ID instead of string literal.

Adds a setting for a BT watchdog. When turned on, it will toggle the BT off an on once (not more often than once every 12 minutes). This helps on some phones that they can re-establish the connection.