### PR TITLE
Use autosensdata for wizard instead of  APSResult

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
@@ -53,6 +53,8 @@ import info.nightscout.androidaps.db.TempTarget;
 import info.nightscout.androidaps.events.EventNewBG;
 import info.nightscout.androidaps.events.EventRefreshOverview;
 import info.nightscout.androidaps.plugins.ConfigBuilder.ConfigBuilderPlugin;
+import info.nightscout.androidaps.plugins.IobCobCalculator.AutosensData;
+import info.nightscout.androidaps.plugins.IobCobCalculator.IobCobCalculatorPlugin;
 import info.nightscout.androidaps.plugins.Loop.LoopPlugin;
 import info.nightscout.androidaps.plugins.OpenAPSAMA.OpenAPSAMAPlugin;
 import info.nightscout.androidaps.plugins.OpenAPSMA.events.EventOpenAPSUpdateGui;
@@ -439,7 +441,7 @@ public class WizardDialog extends DialogFragment implements OnClickListener, Com
         basalIobInsulin.setText(DecimalFormatter.to2Decimal(-basalIob.basaliob) + "U");
 
         // COB only if AMA is selected
-        if (ConfigBuilderPlugin.getActiveAPS() instanceof OpenAPSAMAPlugin && ConfigBuilderPlugin.getActiveAPS().getLastAPSResult() != null && ConfigBuilderPlugin.getActiveAPS().getLastAPSRun().after(new Date(System.currentTimeMillis() - 11 * 60 * 1000L))) {
+        if (ConfigBuilderPlugin.getActiveAPS() instanceof OpenAPSAMAPlugin) {
             cobLayout.setVisibility(View.VISIBLE);
             cobAvailable = true;
         } else {
@@ -483,12 +485,10 @@ public class WizardDialog extends DialogFragment implements OnClickListener, Com
         // COB
         Double c_cob = 0d;
         if (cobAvailable && cobCheckbox.isChecked()) {
-            if (ConfigBuilderPlugin.getActiveAPS().getLastAPSResult() != null && ConfigBuilderPlugin.getActiveAPS().getLastAPSRun().after(new Date(System.currentTimeMillis() - 11 * 60 * 1000L))) {
-                try {
-                    c_cob = SafeParse.stringToDouble(ConfigBuilderPlugin.getActiveAPS().getLastAPSResult().json().getString("COB"));
-                } catch (JSONException e) {
-                    log.error("Unhandled exception", e);
-                }
+            AutosensData autosensData = IobCobCalculatorPlugin.getAutosensData(System.currentTimeMillis());
+
+            if(autosensData != null && autosensData.time > System.currentTimeMillis() - 11 * 60 * 1000L) {
+                c_cob = autosensData.cob;
             }
         }
 


### PR DESCRIPTION
There were multiple issues on FB reportet regarding the Wizard not showing COB at first.
![25593671_1398587443603919_1266871076_n](https://user-images.githubusercontent.com/9692866/34180221-386215a0-e50e-11e7-90e6-7ec31d3dd1d9.png)
![25530305_1398587470270583_1591876266_n](https://user-images.githubusercontent.com/9692866/34180222-388c3c4a-e50e-11e7-84ef-a1a2e67be586.png)

I don't use COB at all, so I can't test it. Please see this only as an idea what could be wrong.

@savek-cc, does that help?