### PR TITLE
illegalState crash fix

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/MainActivity.java
+++ b/app/src/main/java/info/nightscout/androidaps/MainActivity.java
@@ -112,12 +112,16 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                recreate();
-                try { // activity may be destroyed
-                    setUpTabs(true);
-                } catch (IllegalStateException e) {
-                    log.error("Unhandled exception", e);
+                if(ev.recreate) {
+                    recreate();
+                }else {
+                    try { // activity may be destroyed
+                        setUpTabs(true);
+                    } catch (IllegalStateException e) {
+                        log.error("Unhandled exception", e);
+                    }
                 }
+
                 boolean lockScreen = BuildConfig.NSCLIENTOLNY && SP.getBoolean("lockscreen", false);
                 if (lockScreen)
                     getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);

--- a/app/src/main/java/info/nightscout/androidaps/PreferencesActivity.java
+++ b/app/src/main/java/info/nightscout/androidaps/PreferencesActivity.java
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps;
 
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.EditTextPreference;
@@ -58,8 +59,9 @@ public class PreferencesActivity extends PreferenceActivity implements SharedPre
         if (key.equals("language")) {
             String lang = sharedPreferences.getString("language", "en");
             LocaleHelper.setLocale(getApplicationContext(), lang);
-            recreate();
-            MainApp.bus().post(new EventRefreshGui());
+            MainApp.bus().post(new EventRefreshGui(true));
+            //recreate() does not update language so better close settings
+            finish();
         }
         if (key.equals("short_tabtitles")) {
             MainApp.bus().post(new EventRefreshGui());

--- a/app/src/main/java/info/nightscout/androidaps/events/EventRefreshGui.java
+++ b/app/src/main/java/info/nightscout/androidaps/events/EventRefreshGui.java
@@ -4,4 +4,11 @@ package info.nightscout.androidaps.events;
  * Created by mike on 13.06.2016.
  */
 public class EventRefreshGui extends Event {
+    public boolean recreate = false;
+    public EventRefreshGui(boolean recreate) {
+        this.recreate = recreate;
+    }
+    public EventRefreshGui(){
+        this(false);
+    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/tabs/TabPageAdapter.java
+++ b/app/src/main/java/info/nightscout/androidaps/tabs/TabPageAdapter.java
@@ -9,8 +9,12 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
 import android.view.ViewGroup;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 
+import info.nightscout.androidaps.MainActivity;
 import info.nightscout.androidaps.interfaces.PluginBase;
 
 /**
@@ -21,6 +25,8 @@ public class TabPageAdapter extends FragmentStatePagerAdapter {
     ArrayList<PluginBase> visibleFragmentList = new ArrayList<>();
 
     Context context;
+
+    private static Logger log = LoggerFactory.getLogger(TabPageAdapter.class);
 
     public TabPageAdapter(FragmentManager fm, Context context) {
         super(fm);
@@ -40,6 +46,8 @@ public class TabPageAdapter extends FragmentStatePagerAdapter {
             super.finishUpdate(container);
         } catch (NullPointerException nullPointerException){
             System.out.println("Catch the NullPointerException in FragmentStatePagerAdapter.finishUpdate");
+        } catch (IllegalStateException e){
+            log.error(e.getMessage());
         }
     }
 


### PR DESCRIPTION
This is part solution, part workaround for the IllegalState crash on Android 8.1:


The problem with the IllegalState-Exceptions happens every time *after* a `recreate()` on Android 8.1. (Not noticed it on versions prior to that).

This workaround does the following:
1) Catch the exception, as the tabs are setup anyways (just clashes when two activities/threads are trying to do that with the second one).
2) Reduces the amount of times the Main-App calls `recreate()` drastically, by only calling it, when the language needs to be loaded again.

Known issues:
a) Every time, the language is changed and the app is recreated, new listeners get registered to the checkbox, leading to multiple parallel `onClick` triggeres (not much of a problem as they are reduced in amount and do not multiply and no crash with the workaround - but still not nice. Should not lead to performance issues as the language is not changed too often before the App gets restarted.).
b) The Settings won't change the language without the "magic" in the background that led to errors. -> Close Settings when language is changed.