### PR TITLE
Add a unit test for Insulin Plugin

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/data/Iob.java
+++ b/app/src/main/java/info/nightscout/androidaps/data/Iob.java
@@ -12,4 +12,26 @@ public class Iob {
         activityContrib += iob.activityContrib;
         return this;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Iob iob = (Iob) o;
+
+        if (Double.compare(iob.iobContrib, iobContrib) != 0) return false;
+        return Double.compare(iob.activityContrib, activityContrib) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        int result;
+        long temp;
+        temp = Double.doubleToLongBits(iobContrib);
+        result = (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(activityContrib);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Insulin/InsulinOrefBasePlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Insulin/InsulinOrefBasePlugin.java
@@ -1,5 +1,7 @@
 package info.nightscout.androidaps.plugins.Insulin;
 
+import com.squareup.otto.Bus;
+
 import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.R;
 import info.nightscout.androidaps.data.Iob;
@@ -44,23 +46,39 @@ public abstract class InsulinOrefBasePlugin implements PluginBase, InsulinInterf
         return true;
     }
 
+    public Bus getBus() {
+        return MainApp.bus();
+    }
+
     @Override
     public double getDia() {
         double dia = getUserDefinedDia();
         if(dia >= MIN_DIA){
             return dia;
         } else {
-            if((System.currentTimeMillis() - lastWarned) > 60*1000) {
-                lastWarned = System.currentTimeMillis();
-                Notification notification = new Notification(Notification.SHORT_DIA, String.format(MainApp.sResources.getString(R.string.dia_too_short), dia, MIN_DIA), Notification.URGENT);
-                MainApp.bus().post(new EventNewNotification(notification));
-            }
+            sendShortDiaNotification(dia);
             return MIN_DIA;
         }
     }
 
+    void sendShortDiaNotification(double dia) {
+        if((System.currentTimeMillis() - lastWarned) > 60*1000) {
+            lastWarned = System.currentTimeMillis();
+            Notification notification = new Notification(Notification.SHORT_DIA, String.format(this.getNotificationPattern(), dia, MIN_DIA), Notification.URGENT);
+            this.getBus().post(new EventNewNotification(notification));
+        }
+    }
+
+    public String getNotificationPattern() {
+        return MainApp.sResources.getString(R.string.dia_too_short);
+    }
+
     public double getUserDefinedDia() {
         return MainApp.getConfigBuilder().getProfile() != null ? MainApp.getConfigBuilder().getProfile().getDia() : MIN_DIA;
+    }
+
+    public Iob iobCalcForTreatment(Treatment treatment, long time) {
+        return this.iobCalcForTreatment(treatment, time, 0d);
     }
 
     @Override
@@ -69,13 +87,12 @@ public abstract class InsulinOrefBasePlugin implements PluginBase, InsulinInterf
 
         int peak = getPeak();
 
-
         if (treatment.insulin != 0d) {
 
             long bolusTime = treatment.date;
             double t = (time - bolusTime) / 1000d / 60d;
 
-            double td = getDia()*60; //getDIA() always > 5
+            double td = getDia()*60; //getDIA() always >= MIN_DIA
             double tp = peak;
 
             // force the IOB to 0 if over DIA hours have passed

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Insulin/InsulinOrefBasePluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Insulin/InsulinOrefBasePluginTest.java
@@ -1,0 +1,131 @@
+package info.nightscout.androidaps.plugins.Insulin;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import info.nightscout.androidaps.data.Iob;
+import info.nightscout.androidaps.db.Treatment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by triplem on 07.01.18.
+ */
+
+public class InsulinOrefBasePluginTest extends InsulinOrefBasePlugin {
+
+    private int peak;
+    private double dia;
+
+    private boolean shortDiaNotificationSend;
+
+    @Before
+    public void setUp() throws Exception {
+        this.peak = 0;
+        this.dia = InsulinOrefBasePlugin.MIN_DIA;
+        this.shortDiaNotificationSend = false;
+    }
+
+    @Test
+    public void testGetDia() throws Exception {
+        assertEquals(InsulinOrefBasePlugin.MIN_DIA, this.getDia(), 0);
+
+        this.dia = InsulinOrefBasePlugin.MIN_DIA + 1;
+        assertEquals(InsulinOrefBasePlugin.MIN_DIA + 1, this.getDia(), 0);
+
+        this.dia = InsulinOrefBasePlugin.MIN_DIA - 1;
+        assertEquals(InsulinOrefBasePlugin.MIN_DIA, this.getDia(), 0);
+        assertTrue(this.shortDiaNotificationSend);
+    }
+
+    @Test
+    public void testIobCalcForTreatment() {
+        Treatment treatment = new Treatment();
+        Iob expected = new Iob();
+
+        assertEquals(expected, this.iobCalcForTreatment(treatment, 0, 0d));
+
+        this.peak = 30;
+        long time = System.currentTimeMillis();
+        treatment.date = time - 1 * 60 * 60 * 1000; // 1 hour
+        treatment.insulin = 10d;
+
+        assertEquals(3.92, this.iobCalcForTreatment(treatment, time).iobContrib, 0.1);
+    }
+
+
+    /**
+     * this method is implemented to allow tests of the iobCalcForTreatment calculation
+      * @return
+     */
+    @Override
+    int getPeak() {
+        return this.peak;
+    }
+
+    /**
+     * Userdefined Dia is implemented to allow tests of the getDia method
+     *
+     * @return
+     */
+    public double getUserDefinedDia() {
+        return this.dia;
+    }
+
+    void sendShortDiaNotification(double dia) {
+        this.shortDiaNotificationSend = true;
+    }
+
+
+    // the following methods are implemented, but not needed...
+    @Override
+    String commentStandardText() {
+        return null;
+    }
+
+    @Override
+    public String getFragmentClass() {
+        return null;
+    }
+
+    @Override
+    public int getId() {
+        return 0;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public String getFriendlyName() {
+        return null;
+    }
+
+    @Override
+    public boolean isEnabled(int type) {
+        return false;
+    }
+
+    @Override
+    public boolean isVisibleInTabs(int type) {
+        return false;
+    }
+
+    @Override
+    public void setFragmentEnabled(int type, boolean fragmentEnabled) {
+
+    }
+
+    @Override
+    public void setFragmentVisible(int type, boolean fragmentVisible) {
+
+    }
+
+    @Override
+    public int getPreferencesId() {
+        return 0;
+    }
+}


### PR DESCRIPTION
This PR adds a unit test (an easy one) for the InsulinOrefBasePlugin. 

This unit test strongly suggest the usage of dagger2 (Dependency Injection Framework), since the unit test inherits from the InsulinOrefBasePlugin, which should not be really the case. Properties in this Class are retrieved from other classes (eg. MainApp). Some of those dependencies are already factored out into their own methods, to be able to reset those to testable values.

