### PR TITLE
Overview: move checkboxes before label.

### DIFF
--- a/app/src/main/res/layout/overview_fragment.xml
+++ b/app/src/main/res/layout/overview_fragment.xml
@@ -245,6 +245,13 @@
                     android:orientation="horizontal"
                     android:paddingTop="5dp">
 
+                    <CheckBox
+                        android:id="@+id/overview_showprediction"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        app:buttonTint="@color/prediction" />
+
                     <TextView
                         android:id="@+id/overview_showprediction_label"
                         android:layout_width="wrap_content"
@@ -254,22 +261,6 @@
                         android:textAppearance="?android:attr/textAppearanceSmall"
                         android:textColor="@color/prediction"
                         android:textStyle="bold"/>
-
-                    <CheckBox
-                        android:id="@+id/overview_showprediction"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        app:buttonTint="@color/prediction" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:text="@string/basalshortlabel"
-                        android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="@color/basal"
-                        android:textStyle="bold" />
 
                     <CheckBox
                         android:id="@+id/overview_showbasals"
@@ -282,9 +273,9 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@string/iob"
+                        android:text="@string/basalshortlabel"
                         android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="@color/iob"
+                        android:textColor="@color/basal"
                         android:textStyle="bold" />
 
                     <CheckBox
@@ -298,10 +289,11 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@string/cob"
+                        android:text="@string/iob"
                         android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="@color/cob"
+                        android:textColor="@color/iob"
                         android:textStyle="bold" />
+
 
                     <CheckBox
                         android:id="@+id/overview_showcob"
@@ -314,9 +306,9 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@string/dev"
+                        android:text="@string/cob"
                         android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="@color/deviations"
+                        android:textColor="@color/cob"
                         android:textStyle="bold" />
 
                     <CheckBox
@@ -330,8 +322,9 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@string/ratio_short"
+                        android:text="@string/dev"
                         android:textAppearance="?android:attr/textAppearanceSmall"
+                        android:textColor="@color/deviations"
                         android:textStyle="bold" />
 
                     <CheckBox
@@ -339,6 +332,14 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:text="@string/ratio_short"
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        android:textStyle="bold" />
 
                 </LinearLayout>
 

--- a/app/src/main/res/layout/overview_fragment_nsclient.xml
+++ b/app/src/main/res/layout/overview_fragment_nsclient.xml
@@ -474,6 +474,13 @@
                 android:orientation="horizontal"
                 android:paddingTop="5dp">
 
+                <CheckBox
+                    android:id="@+id/overview_showprediction"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    app:buttonTint="@color/prediction" />
+
                 <TextView
                     android:id="@+id/overview_showprediction_label"
                     android:layout_width="wrap_content"
@@ -483,22 +490,6 @@
                     android:textAppearance="?android:attr/textAppearanceSmall"
                     android:textColor="@color/prediction"
                     android:textStyle="bold"/>
-
-                <CheckBox
-                    android:id="@+id/overview_showprediction"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    app:buttonTint="@color/prediction" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:text="@string/basalshortlabel"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="@color/basal"
-                    android:textStyle="bold" />
 
                 <CheckBox
                     android:id="@+id/overview_showbasals"
@@ -511,9 +502,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:text="@string/iob"
+                    android:text="@string/basalshortlabel"
                     android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="@color/iob"
+                    android:textColor="@color/basal"
                     android:textStyle="bold" />
 
                 <CheckBox
@@ -527,10 +518,11 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:text="@string/cob"
+                    android:text="@string/iob"
                     android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="@color/cob"
+                    android:textColor="@color/iob"
                     android:textStyle="bold" />
+
 
                 <CheckBox
                     android:id="@+id/overview_showcob"
@@ -543,9 +535,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:text="@string/dev"
+                    android:text="@string/cob"
                     android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="@color/deviations"
+                    android:textColor="@color/cob"
                     android:textStyle="bold" />
 
                 <CheckBox
@@ -559,8 +551,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:text="@string/ratio_short"
+                    android:text="@string/dev"
                     android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="@color/deviations"
                     android:textStyle="bold" />
 
                 <CheckBox
@@ -568,6 +561,14 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="@string/ratio_short"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textStyle="bold" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/overview_fragment_nsclient_tablet.xml
+++ b/app/src/main/res/layout/overview_fragment_nsclient_tablet.xml
@@ -558,6 +558,13 @@
                     android:orientation="horizontal"
                     android:paddingTop="5dp">
 
+                    <CheckBox
+                        android:id="@+id/overview_showprediction"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        app:buttonTint="@color/prediction" />
+
                     <TextView
                         android:id="@+id/overview_showprediction_label"
                         android:layout_width="wrap_content"
@@ -567,22 +574,6 @@
                         android:textAppearance="?android:attr/textAppearanceSmall"
                         android:textColor="@color/prediction"
                         android:textStyle="bold"/>
-
-                    <CheckBox
-                        android:id="@+id/overview_showprediction"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        app:buttonTint="@color/prediction" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:text="@string/basalshortlabel"
-                        android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="@color/basal"
-                        android:textStyle="bold" />
 
                     <CheckBox
                         android:id="@+id/overview_showbasals"
@@ -595,9 +586,9 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@string/iob"
+                        android:text="@string/basalshortlabel"
                         android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="@color/iob"
+                        android:textColor="@color/basal"
                         android:textStyle="bold" />
 
                     <CheckBox
@@ -611,10 +602,11 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@string/cob"
+                        android:text="@string/iob"
                         android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="@color/cob"
+                        android:textColor="@color/iob"
                         android:textStyle="bold" />
+
 
                     <CheckBox
                         android:id="@+id/overview_showcob"
@@ -627,9 +619,9 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@string/dev"
+                        android:text="@string/cob"
                         android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="@color/deviations"
+                        android:textColor="@color/cob"
                         android:textStyle="bold" />
 
                     <CheckBox
@@ -643,8 +635,9 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@string/ratio_short"
+                        android:text="@string/dev"
                         android:textAppearance="?android:attr/textAppearanceSmall"
+                        android:textColor="@color/deviations"
                         android:textStyle="bold" />
 
                     <CheckBox
@@ -652,6 +645,14 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:text="@string/ratio_short"
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        android:textStyle="bold" />
 
                 </LinearLayout>
 

--- a/app/src/main/res/layout/overview_fragment_smallheight.xml
+++ b/app/src/main/res/layout/overview_fragment_smallheight.xml
@@ -240,6 +240,13 @@
                 android:orientation="horizontal"
                 android:paddingTop="5dp">
 
+                <CheckBox
+                    android:id="@+id/overview_showprediction"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    app:buttonTint="@color/prediction" />
+
                 <TextView
                     android:id="@+id/overview_showprediction_label"
                     android:layout_width="wrap_content"
@@ -249,22 +256,6 @@
                     android:textAppearance="?android:attr/textAppearanceSmall"
                     android:textColor="@color/prediction"
                     android:textStyle="bold"/>
-
-                <CheckBox
-                    android:id="@+id/overview_showprediction"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    app:buttonTint="@color/prediction" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:text="@string/basalshortlabel"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="@color/basal"
-                    android:textStyle="bold" />
 
                 <CheckBox
                     android:id="@+id/overview_showbasals"
@@ -277,9 +268,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:text="@string/iob"
+                    android:text="@string/basalshortlabel"
                     android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="@color/iob"
+                    android:textColor="@color/basal"
                     android:textStyle="bold" />
 
                 <CheckBox
@@ -293,10 +284,11 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:text="@string/cob"
+                    android:text="@string/iob"
                     android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="@color/cob"
+                    android:textColor="@color/iob"
                     android:textStyle="bold" />
+
 
                 <CheckBox
                     android:id="@+id/overview_showcob"
@@ -309,9 +301,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:text="@string/dev"
+                    android:text="@string/cob"
                     android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="@color/deviations"
+                    android:textColor="@color/cob"
                     android:textStyle="bold" />
 
                 <CheckBox
@@ -325,8 +317,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:text="@string/ratio_short"
+                    android:text="@string/dev"
                     android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="@color/deviations"
                     android:textStyle="bold" />
 
                 <CheckBox
@@ -334,6 +327,14 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="@string/ratio_short"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textStyle="bold" />
 
             </LinearLayout>
 


### PR DESCRIPTION
This applies the default layout new users expect from other apps and such.

![image](https://user-images.githubusercontent.com/1732305/35168530-93880d00-fd59-11e7-89e3-7d93768fd24b.png)
