### PR TITLE
Add issue template.

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+Reporting bugs
+--------------
+- Note the precise time the problem occurred and describe the circumstances and steps that caused
+  the problem
+- Note the Build version (found in the About dialog in the app, when pressing the three dots in the
+  upper-right corner).
+- Obtain the app's log files, which can be found on the phone in
+  _/storage/emulated/0/Android/data/info.nightscout.androidaps/_
+  See https://github.com/MilosKozak/AndroidAPS/wiki/Accessing-logfiles
+- Open an issue at https://github.com/MilosKozak/AndroidAPS/issues/new


### PR DESCRIPTION
Adding `ISSUE-TEMPLATE.md` will prefill a new issue like so (often as a form with blanks to fill in):
![image](https://user-images.githubusercontent.com/1732305/35626176-30676c76-0695-11e8-8689-99a867d2a8fd.png)
If a file `CONTRIBUTING.md` exists, a link to it will also be show as seen in the screenshot.
GitHub also allows putting the above files into a subfolder (.github I think, would have to check).

Useful or futile?