### PR TITLE
update bg for treatment in the past via careportal

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Careportal/Dialogs/NewNSTreatmentDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Careportal/Dialogs/NewNSTreatmentDialog.java
@@ -29,7 +29,6 @@ import com.wdullaer.materialdatetimepicker.date.DatePickerDialog;
 import com.wdullaer.materialdatetimepicker.time.RadialPickerLayout;
 import com.wdullaer.materialdatetimepicker.time.TimePickerDialog;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Careportal/Dialogs/NewNSTreatmentDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Careportal/Dialogs/NewNSTreatmentDialog.java
@@ -29,6 +29,7 @@ import com.wdullaer.materialdatetimepicker.date.DatePickerDialog;
 import com.wdullaer.materialdatetimepicker.time.RadialPickerLayout;
 import com.wdullaer.materialdatetimepicker.time.TimePickerDialog;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -38,6 +39,7 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
 import info.nightscout.androidaps.Constants;
 import info.nightscout.androidaps.MainApp;
@@ -45,6 +47,7 @@ import info.nightscout.androidaps.R;
 import info.nightscout.androidaps.data.GlucoseStatus;
 import info.nightscout.androidaps.data.Profile;
 import info.nightscout.androidaps.data.ProfileStore;
+import info.nightscout.androidaps.db.BgReading;
 import info.nightscout.androidaps.db.CareportalEvent;
 import info.nightscout.androidaps.db.ProfileSwitch;
 import info.nightscout.androidaps.db.Source;
@@ -407,12 +410,23 @@ public class NewNSTreatmentDialog extends DialogFragment implements View.OnClick
         else layout.setVisibility(View.GONE);
     }
 
+    private void updateBGforDateTime() {
+        long millis = eventTime.getTime() - (150 * 1000L); // 2,5 * 60 * 1000
+        List<BgReading> data = MainApp.getDbHelper().getBgreadingsDataFromTime(millis, true);
+        if ((data.size() > 0) &&
+            (data.get(0).date > millis - 7 * 60 * 1000L) &&
+            (data.get(0).date < millis + 7 * 60 * 1000L)) {
+            editBg.setValue(data.get(0).value);
+        }
+    }
+
     @Override
     public void onDateSet(DatePickerDialog view, int year, int monthOfYear, int dayOfMonth) {
         eventTime.setYear(year - 1900);
         eventTime.setMonth(monthOfYear);
         eventTime.setDate(dayOfMonth);
         dateButton.setText(DateUtil.dateString(eventTime));
+        updateBGforDateTime();
     }
 
     @Override
@@ -421,6 +435,7 @@ public class NewNSTreatmentDialog extends DialogFragment implements View.OnClick
         eventTime.setMinutes(minute);
         eventTime.setSeconds(second);
         timeButton.setText(DateUtil.timeString(eventTime));
+        updateBGforDateTime();
     }
 
 


### PR DESCRIPTION
Maybe there's a better way to do it (adding a function to GlucoseStatus?) but I hope this gets the point across ;)
Basically when entering a treatment via careportal, the bg value is taken from "now" - if I change the time because I want to enter carbs from 1h ago, the bg value stays at the current one.
In order to have the right bg value for this entry in the past, I would have to look up the bg value in nightscout and then enter it here.
Using this patch, the bg value is updated with the historic value as soon as the user enters a different time or date.