### PR TITLE
Updates to Insight plugin

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/InsightPumpAsyncAdapter.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/InsightPumpAsyncAdapter.java
@@ -56,7 +56,7 @@ public class InsightPumpAsyncAdapter {
     }
 
     // blocking call to wait for result callback
-    Cstatus busyWaitForCommandResult(final UUID uuid, long wait_time) {
+    private Cstatus busyWaitForCommandInternal(final UUID uuid, long wait_time) {
         final PowerManager.WakeLock wl = getWakeLock("insight-wait-cmd", 60000);
         try {
             log("busy wait for command " + uuid);
@@ -82,25 +82,14 @@ public class InsightPumpAsyncAdapter {
         }
     }
 
-    // commend field preparation for results
-    String getCommandComment(final UUID uuid) {
-        if (commandResults.containsKey(uuid)) {
-            if (commandResults.get(uuid).success) {
-                return "OK";
-            } else {
-                return commandResults.get(uuid).message;
-            }
-        } else {
-            return "Unknown reference";
-        }
+    // wait for and then package result, cleanup and return
+    Mstatus busyWaitForCommandResult(final UUID uuid, long wait_time) {
+        final Mstatus mstatus = new Mstatus();
+        mstatus.cstatus = busyWaitForCommandInternal(uuid, wait_time);
+        mstatus.event = commandResults.get(uuid);
+        commandResults.remove(uuid);
+        return mstatus;
     }
 
-    int getResponseID(UUID uuid) {
-        if (checkCommandResult(uuid) == Cstatus.SUCCESS) {
-            return commandResults.get(uuid).response_id;
-        } else {
-            return -2; // invalid
-        }
-    }
 
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/InsightPumpPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/InsightPumpPlugin.java
@@ -463,6 +463,11 @@ public class InsightPumpPlugin implements PluginBase, PumpInterface, Constraints
         log("Calculated requested rate: " + absoluteRate + " base rate: " + base_basal + " percentage: " + amount + "%");
         amount = (int) Math.round(((double) amount) / 10d) * 10;
         log("Calculated final rate: " + amount + "%");
+
+        if (amount == 100) {
+            return cancelTempBasal(false);
+        }
+
         if (amount > 250) amount = 250;
 
         final SetTBRTaskRunner task = new SetTBRTaskRunner(connector.getServiceConnector(), amount, durationInMinutes);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/Mstatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/Mstatus.java
@@ -1,0 +1,50 @@
+package info.nightscout.androidaps.plugins.PumpInsight;
+
+import info.nightscout.androidaps.plugins.PumpInsight.events.EventInsightPumpCallback;
+
+/**
+ * Created by jamorham on 01/02/2018.
+ *
+ * Encapsulates results from commands
+ */
+
+class Mstatus {
+
+    Cstatus cstatus = Cstatus.UNKNOWN;
+    EventInsightPumpCallback event;
+
+    // comment field preparation for results
+    String getCommandComment() {
+        if (success()) {
+            return "OK";
+        } else {
+            return (event == null) ? "EVENT IS NULL" : event.message;
+        }
+    }
+
+    boolean success() {
+        return cstatus.success();
+    }
+
+    int getResponseID() {
+        if (success()) {
+            return event.response_id;
+        } else {
+            return -2; // invalid
+        }
+    }
+
+    Object getResponseObject() {
+        if (success()) {
+            return event.response_object;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return cstatus + " " + event;
+    }
+
+}

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/Mstatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/Mstatus.java
@@ -18,7 +18,7 @@ class Mstatus {
         if (success()) {
             return "OK";
         } else {
-            return (event == null) ? "EVENT IS NULL" : event.message;
+            return (event == null) ? "EVENT DATA IS NULL - ERROR OR FIREWALL ENABLED?" : event.message;
         }
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/connector/SetTBRTaskRunner.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/connector/SetTBRTaskRunner.java
@@ -1,0 +1,51 @@
+package info.nightscout.androidaps.plugins.PumpInsight.connector;
+
+import sugar.free.sightparser.applayer.messages.AppLayerMessage;
+import sugar.free.sightparser.applayer.messages.remote_control.ChangeTBRMessage;
+import sugar.free.sightparser.applayer.messages.remote_control.SetTBRMessage;
+import sugar.free.sightparser.applayer.messages.status.CurrentTBRMessage;
+import sugar.free.sightparser.handling.SightServiceConnector;
+import sugar.free.sightparser.handling.TaskRunner;
+
+// from Tebbe - note this uses 1 minute duration to silently cancel existing TBR
+
+public class SetTBRTaskRunner extends TaskRunner {
+
+    private int amount;
+    private int duration;
+
+    public SetTBRTaskRunner(SightServiceConnector serviceConnector, int amount, int duration) {
+        super(serviceConnector);
+        this.amount = amount;
+        this.duration = duration;
+    }
+
+    @Override
+    protected AppLayerMessage run(AppLayerMessage message) throws Exception {
+        if (message == null) return new CurrentTBRMessage();
+        else if (message instanceof CurrentTBRMessage) {
+            if (((CurrentTBRMessage) message).getPercentage() == 100) {
+                if (amount == 100) finish(amount);
+                else {
+                    SetTBRMessage setTBRMessage = new SetTBRMessage();
+                    setTBRMessage.setDuration((short) duration);
+                    setTBRMessage.setAmount((short) amount);
+                    return setTBRMessage;
+                }
+            } else {
+                if (amount == 100) {
+                    ChangeTBRMessage changeTBRMessage = new ChangeTBRMessage();
+                    changeTBRMessage.setDuration((short) 1);
+                    changeTBRMessage.setAmount((short) 90);
+                    return changeTBRMessage;
+                } else {
+                    ChangeTBRMessage changeTBRMessage = new ChangeTBRMessage();
+                    changeTBRMessage.setDuration((short) duration);
+                    changeTBRMessage.setAmount((short) amount);
+                    return changeTBRMessage;
+                }
+            }
+        } else if (message instanceof SetTBRMessage) finish(amount);
+        return null;
+    }
+}

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/events/EventInsightPumpCallback.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/events/EventInsightPumpCallback.java
@@ -13,6 +13,7 @@ public class EventInsightPumpCallback extends Event {
     public boolean success = false;
     public String message = null;
     public int response_id = -1;
+    public Object response_object = null;
 
     public EventInsightPumpCallback() {
         request_uuid = UUID.randomUUID();
@@ -20,7 +21,7 @@ public class EventInsightPumpCallback extends Event {
 
     @Override
     public String toString() {
-        return "Event: " + request_uuid + " success: " + success + " msg: " + message;
+        return "Event: " + request_uuid + " success: " + success + " msg: " + message + " Object: " + response_object;
     }
 
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/history/HistoryIntentAdapter.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/history/HistoryIntentAdapter.java
@@ -4,7 +4,6 @@ import android.content.Intent;
 
 import java.util.Date;
 
-import info.nightscout.utils.SP;
 import sugar.free.sightparser.handling.HistoryBroadcast;
 
 import static info.nightscout.androidaps.plugins.PumpInsight.history.PumpIdCache.updatePumpSerialNumber;
@@ -50,9 +49,12 @@ class HistoryIntentAdapter {
         final long record_unique_id = getRecordUniqueID(pump_serial_number, pump_record_id);
 
         // other sanity checks
-        log("Creating TBR record: " + pump_tbr_percent + "% " + pump_tbr_duration + "m" + " id:" + record_unique_id);
-        logAdapter.createTBRrecord(start_time, pump_tbr_percent, pump_tbr_duration, record_unique_id);
-
+        if ((pump_tbr_percent == 90) && (pump_tbr_duration <= 1)) {
+            log("Not creating TBR record for faux cancel");
+        } else {
+            log("Creating TBR record: " + pump_tbr_percent + "% " + pump_tbr_duration + "m" + " id:" + record_unique_id);
+            logAdapter.createTBRrecord(start_time, pump_tbr_percent, pump_tbr_duration, record_unique_id);
+        }
     }
 
     void processDeliveredBolusIntent(Intent intent) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/history/HistoryLogAdapter.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/history/HistoryLogAdapter.java
@@ -17,7 +17,7 @@ import info.nightscout.androidaps.db.TemporaryBasal;
 
 class HistoryLogAdapter {
 
-    private static final long MAX_TIME_DIFFERENCE = 5000;
+    private static final long MAX_TIME_DIFFERENCE = 61000;
 
     private static void log(String msg) {
         android.util.Log.e("HISTORYLOG", msg);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/history/HistoryLogAdapter.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/history/HistoryLogAdapter.java
@@ -17,10 +17,39 @@ import info.nightscout.androidaps.db.TemporaryBasal;
 
 class HistoryLogAdapter {
 
+    private static final long MAX_TIME_DIFFERENCE = 5000;
+
+    private static void log(String msg) {
+        android.util.Log.e("HISTORYLOG", msg);
+    }
+
     void createTBRrecord(Date eventDate, int percent, int duration, long record_id) {
 
-        final TemporaryBasal temporaryBasal = new TemporaryBasal();
-        temporaryBasal.date = eventDate.getTime();
+        TemporaryBasal temporaryBasal = new TemporaryBasal(eventDate.getTime());
+
+        final TemporaryBasal temporaryBasalFromHistory = MainApp.getConfigBuilder().getTempBasalFromHistory(eventDate.getTime());
+
+        if (temporaryBasalFromHistory == null) {
+            log("Create new TBR: " + eventDate + " " + percent + " " + duration);
+        } else {
+            log("Loaded existing TBR record: " + temporaryBasalFromHistory.toString());
+            if (Math.abs(eventDate.getTime() - temporaryBasalFromHistory.date) < MAX_TIME_DIFFERENCE) {
+                if (temporaryBasalFromHistory.source != Source.PUMP) {
+                    if (temporaryBasalFromHistory.percentRate == percent) {
+                        log("Things seem to match: %" + percent);
+                        temporaryBasal = temporaryBasalFromHistory;
+                        MainApp.getDbHelper().delete(temporaryBasalFromHistory);
+                    } else {
+                        log("This record has different percent rates: " + temporaryBasalFromHistory.percentRate + " vs us: " + percent);
+                    }
+                } else {
+                    log("This record is already a pump record!");
+                }
+            } else {
+                log("Time difference too great! : " + (eventDate.getTime() - temporaryBasalFromHistory.date));
+            }
+        }
+
         temporaryBasal.source = Source.PUMP;
         temporaryBasal.pumpId = record_id;
         temporaryBasal.percentRate = percent;
@@ -46,6 +75,8 @@ class HistoryLogAdapter {
     void createStandardBolusRecord(Date eventDate, double insulin, long record_id) {
 
         //DetailedBolusInfo detailedBolusInfo = DetailedBolusInfoStorage.findDetailedBolusInfo(eventDate.getTime());
+
+        // TODO do we need to do the same delete + insert that we are doing for temporary basals here too?
 
         final DetailedBolusInfo detailedBolusInfo = new DetailedBolusInfo();
         detailedBolusInfo.date = eventDate.getTime();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -879,7 +879,7 @@
     <string name="insight_upfront_with">upfront with</string>
     <string name="insight_stay_always_connected">Stay always connected</string>
     <string name="insight_use_real_tbr_cancels">Use Real TBR cancels</string>
-    <string name="insight_actually_cancel_tbr_summary">Actually cancel a TBR (creates pump alarm) instead of setting 90% or 110% TBR for 15 minutes</string>
+    <string name="insight_actually_cancel_tbr_summary">Actually cancel a TBR (creates pump alarm) instead of setting 90% for 1 minute</string>
     <string name="insight_history_idle">IDLE</string>
     <string name="insight_history_syncing">SYNCING</string>
     <string name="insight_history_busy">BUSY</string>


### PR DESCRIPTION
This PR contains a number of improvements to the Insight plugin:

- It implements the `ConstraintsInterface` with the known defaults for the pump
- Absolute TBRs are handled better and percentage rates are calculated more accurately.
- Faux TBR cancels are more efficient, setting 90% for 1 minute instead of 15
- History merging of pump records vs internally logged TBRs is significantly improved
- Internally more data is available from the result of requests to the SightRemote service making the implementation more flexible.
- Tested locally for a number of days with good results.

Thanks to @TebbeUbben for much assistance and testing.