### PR TITLE
Set a higher hard limit for IC ratio

### DIFF
--- a/app/src/main/java/info/nightscout/utils/HardLimits.java
+++ b/app/src/main/java/info/nightscout/utils/HardLimits.java
@@ -34,7 +34,7 @@ public class HardLimits {
     public static final double MAXDIA = 7;
 
     public static final double MINIC = 2;
-    public static final double MAXIC = 40;
+    public static final double MAXIC = 100;
 
     public static final double MINISF = 2; // mgdl
     public static final double MAXISF = 720; // mgdl


### PR DESCRIPTION
As written in a comment and in the AAPS thread, I think the new upper hard limit of the IC ratio is to low, for childs but also for me (that's why I found the problem). So I propose a file change.
I run a profile with IC = 60 g when I do long lasting sports activities, the limit of 40 is much to low - and I'm shure that there are childs which have a higher IC ratio in real life. I propose the value of 100 which is relativly compared not as high as the hard limit MAXISF = 720 mg/dl.