### PR TITLE
Quick fix for Insight event handling when not enabled

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/connector/Connector.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/connector/Connector.java
@@ -494,16 +494,18 @@ public class Connector {
 
     @Subscribe
     public void onStatusEvent(final EventFeatureRunning ev) {
-        if (SP.getBoolean("insight_preemptive_connect", true)) {
-            switch (ev.getFeature()) {
-                case WIZARD:
-                    log("Wizard feature detected, preconnecting to pump");
-                    connectToPump(120 * 1000);
-                    break;
-                case MAIN:
-                    log("Main feature detected, preconnecting to pump");
-                    connectToPump(30 * 1000);
-                    break;
+        if (isConnected()) {
+            if (SP.getBoolean("insight_preemptive_connect", true)) {
+                switch (ev.getFeature()) {
+                    case WIZARD:
+                        log("Wizard feature detected, preconnecting to pump");
+                        connectToPump(120 * 1000);
+                        break;
+                    case MAIN:
+                        log("Main feature detected, preconnecting to pump");
+                        connectToPump(30 * 1000);
+                        break;
+                }
             }
         }
     }


### PR DESCRIPTION
This is a quick fix to prevent the crash if the event handler gets fired when not using Insight. I will update the lifecycle for the connector so it only is instantiated when the plugin is enabled rather than when it is instantiated but for now this will fix the crash.