### PR TITLE
Improve Insight Connector life-cycle handling

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/InsightPumpPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpInsight/InsightPumpPlugin.java
@@ -500,21 +500,7 @@ public class InsightPumpPlugin implements PluginBase, PumpInterface, Constraints
 
         if (percent_amount > 250) percent_amount = 250;
 
-        // TODO this is experimental and not enabled due to preference option
-        // ignore TBR changes if the setting is enabled and they are not 0% but are +- 30% of where we are now or we've been running is TBR < 15 minutes
-        if ((percent_amount != 0)
-                && (SP.getBoolean("insight_dont_change_active_tbr", false)
-                && MainApp.getConfigBuilder().isTempBasalInProgress())) {
-            final TemporaryBasal temporaryBasalFromHistory = MainApp.getConfigBuilder().getTempBasalFromHistory(System.currentTimeMillis());
-            if ((temporaryBasalFromHistory != null) && (temporaryBasalFromHistory.isInProgress())) {
-                // only change if it is +- 30% from where we are now or we have done more than 15 minutes already
-                if ((Math.abs(temporaryBasalFromHistory.percentRate - percent_amount) <= 30)
-                        || (temporaryBasalFromHistory.getPlannedRemainingMinutes() > 15)) {
-                    log("Refusing to change TBR due to Insight plugin setting: " + percent_amount + " vs " + temporaryBasalFromHistory.percentRate + " running for: " + temporaryBasalFromHistory.getRealDuration());
-                    return new PumpEnactResult().enacted(false).success(true);
-                }
-            }
-        }
+      
 
         final SetTBRTaskRunner task = new SetTBRTaskRunner(connector.getServiceConnector(), percent_amount, durationInMinutes);
         final UUID cmd = aSyncTaskRunner(task, "Set TBR abs: " + absoluteRate + " " + durationInMinutes + "m");

--- a/app/src/main/java/info/nightscout/androidaps/queue/QueueThread.java
+++ b/app/src/main/java/info/nightscout/androidaps/queue/QueueThread.java
@@ -41,7 +41,6 @@ public class QueueThread extends Thread {
 
         this.queue = queue;
         PowerManager powerManager = (PowerManager) MainApp.instance().getApplicationContext().getSystemService(Context.POWER_SERVICE);
-        //mWakeLock = powerManager.newWakeLock(PowerManager.SCREEN_DIM_WAKE_LOCK, "QueueThread");
         mWakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "QueueThread");
     }
 


### PR DESCRIPTION
This PR resolves the reported bug of crashes from the event bus due to the Insight `Connector` being instantiated when it shouldn't be. Apologies for this oversight.

Primarily this is done with proper life-cycle handling such that the `Connnector` is not instantiated until the plugin is actually enabled and likewise is shut-down properly when the plugin is disabled.

Additionally checks are added to the event bus receiver (as per the earlier quick-fix PR) and on advice from @AdrianLxM I have added a background thread here although I don't think any of the operations would have blocked for any significant time, but this will provide some future-proofing or if android behaves in an unpredictable way.

Based on previous comments by @jotomo and @AdrianLxM I have removed a redundant commented code line and some not-in-use experimental code from the plugin.

This has been tested in an offline environment with some limited live testing, but I will perform more live testing over the next few hours and confirm that this is good. 