### PR TITLE
Make openapsama_current_basal_safety_multiplier Double instead of Int

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/ConstraintsSafety/SafetyPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/ConstraintsSafety/SafetyPlugin.java
@@ -130,7 +130,7 @@ public class SafetyPlugin implements PluginBase, ConstraintsInterface {
         if (profile == null) return absoluteRate;
         if (absoluteRate < 0) absoluteRate = 0d;
 
-        Integer maxBasalMult = SP.getInt("openapsama_current_basal_safety_multiplier", 4);
+        Double maxBasalMult = SP.getDouble("openapsama_current_basal_safety_multiplier", 4d);
         Integer maxBasalFromDaily = SP.getInt("openapsama_max_daily_safety_multiplier", 3);
         // Check percentRate but absolute rate too, because we know real current basal in pump
         Double origRate = absoluteRate;
@@ -168,7 +168,7 @@ public class SafetyPlugin implements PluginBase, ConstraintsInterface {
 
         if (absoluteRate < 0) absoluteRate = 0d;
 
-        Integer maxBasalMult = SP.getInt("openapsama_current_basal_safety_multiplier", 4);
+        Double maxBasalMult = SP.getDouble("openapsama_current_basal_safety_multiplier", 4d);
         Integer maxBasalFromDaily = SP.getInt("openapsama_max_daily_safety_multiplier", 3);
         // Check percentRate but absolute rate too, because we know real current basal in pump
         Double origRate = absoluteRate;

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
@@ -206,7 +206,7 @@ public class DetermineBasalAdapterAMAJS {
         mProfile.put("carb_ratio", profile.getIc());
         mProfile.put("sens", Profile.toMgdl(profile.getIsf().doubleValue(), units));
         mProfile.put("max_daily_safety_multiplier", SP.getInt("openapsama_max_daily_safety_multiplier", 3));
-        mProfile.put("current_basal_safety_multiplier", SP.getInt("openapsama_current_basal_safety_multiplier", 4));
+        mProfile.put("current_basal_safety_multiplier", SP.getDouble("openapsama_current_basal_safety_multiplier", 4d));
         mProfile.put("skip_neutral_temps", true);
         mProfile.put("current_basal", basalrate);
         mProfile.put("temptargetSet", tempTargetSet);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
@@ -230,7 +230,7 @@ public class DetermineBasalAdapterSMBJS {
         mProfile.put("carb_ratio", profile.getIc());
         mProfile.put("sens", Profile.toMgdl(profile.getIsf().doubleValue(), units));
         mProfile.put("max_daily_safety_multiplier", SP.getInt("openapsama_max_daily_safety_multiplier", 3));
-        mProfile.put("current_basal_safety_multiplier", SP.getInt("openapsama_current_basal_safety_multiplier", 4));
+        mProfile.put("current_basal_safety_multiplier", SP.getDouble("openapsama_current_basal_safety_multiplier", 4d));
 
         mProfile.put("high_temptarget_raises_sensitivity", SMBDefaults.high_temptarget_raises_sensitivity);
         mProfile.put("low_temptarget_lowers_sensitivity", SMBDefaults.low_temptarget_lowers_sensitivity);

--- a/app/src/main/res/xml/pref_advanced.xml
+++ b/app/src/main/res/xml/pref_advanced.xml
@@ -63,9 +63,9 @@
                     android:selectAllOnFocus="true"
                     android:singleLine="true"
                     android:title="@string/openapsama_current_basal_safety_multiplier"
-                    validate:maxNumber="10"
-                    validate:minNumber="1"
-                    validate:testType="numericRange" />
+                    validate:floatmaxNumber="10"
+                    validate:floatminNumber="1"
+                    validate:testType="floatNumericRange" />
                 <com.andreabaccega.widget.ValidatingEditTextPreference
                     android:defaultValue="1.2"
                     android:dialogMessage="@string/openapsama_autosens_max_summary"


### PR DESCRIPTION
This PR is to change `openapsama_current_basal_safety_multiplier` to be a Double instead of an Integer

The reason for this change is so that it can be set to for example `2.5` so that requested max basals would be limited to 250% instead of 300% in my usage case where the closest I could set it was `3` previously.

I have searched through the code and changed all the references to this preference item. Someone else should double check my work due to the importance of this parameter.

Because the preference is stored as a string and interpreted, this change set is easier than I first imagined.

I have not tested what would happen if someone upgrades to this version, changes the value to something with a decimal point and then downgrades. I don't know whether the old Integer parsing will convert to the nearest integer or cause an exception or something else.