### PR TITLE
fix 5m-impact parameter - always was 0

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/DetermineBasalAdapterAMAJS.java
@@ -211,7 +211,8 @@ public class DetermineBasalAdapterAMAJS {
         mProfile.put("current_basal", basalrate);
         mProfile.put("temptargetSet", tempTargetSet);
         mProfile.put("autosens_adjust_targets", SP.getBoolean("openapsama_autosens_adjusttargets", true));
-        mProfile.put("min_5m_carbimpact", SP.getInt("openapsama_min_5m_carbimpact", SMBDefaults.min_5m_carbimpact));
+        //TODO: align with max-absorption model in AMA sensitivity
+        mProfile.put("min_5m_carbimpact", SP.getDouble("openapsama_min_5m_carbimpact", SMBDefaults.min_5m_carbimpact));
 
         if (units.equals(Constants.MMOL)) {
             mProfile.put("out_units", "mmol/L");

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
@@ -241,7 +241,8 @@ public class DetermineBasalAdapterSMBJS {
         mProfile.put("half_basal_exercise_target", SMBDefaults.half_basal_exercise_target);
         mProfile.put("maxCOB", SMBDefaults.maxCOB);
         mProfile.put("skip_neutral_temps", SMBDefaults.skip_neutral_temps);
-        mProfile.put("min_5m_carbimpact", SP.getInt("openapsama_min_5m_carbimpact", SMBDefaults.min_5m_carbimpact));;
+        //TODO: align with max-absorption model in AMA sensitivity
+        mProfile.put("min_5m_carbimpact", SP.getDouble("openapsama_min_5m_carbimpact", SMBDefaults.min_5m_carbimpact));;
         mProfile.put("remainingCarbsCap", SMBDefaults.remainingCarbsCap);
         mProfile.put("enableUAM", SP.getBoolean(R.string.key_use_uam, false));
         mProfile.put("A52_risk_enable", SMBDefaults.A52_risk_enable);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/SMBDefaults.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/SMBDefaults.java
@@ -40,7 +40,7 @@ public class SMBDefaults {
     public final static boolean skip_neutral_temps = true; // ***** default false in oref1 ***** if true, don't set neutral temps
     // unsuspend_if_no_temp:false // if true, pump will un-suspend after a zero temp finishes
     // bolussnooze_dia_divisor:2 // bolus snooze decays after 1/2 of DIA
-    public final static int min_5m_carbimpact = 8; // mg/dL per 5m (8 mg/dL/5m corresponds to 24g/hr at a CSF of 4 mg/dL/g (x/5*60/4))
+    public final static double min_5m_carbimpact = 8d; // mg/dL per 5m (8 mg/dL/5m corresponds to 24g/hr at a CSF of 4 mg/dL/g (x/5*60/4))
     public final static int remainingCarbsCap = 90; // max carbs we'll assume will absorb over 4h if we don't yet see carb absorption
     // WARNING: use SMB with caution: it can and will automatically bolus up to max_iob worth of extra insulin
     // enableUAM:true // enable detection of unannounced meal carb absorption

--- a/app/src/main/res/xml/pref_absorption_oref0.xml
+++ b/app/src/main/res/xml/pref_absorption_oref0.xml
@@ -7,7 +7,7 @@
         <com.andreabaccega.widget.ValidatingEditTextPreference
             validate:testType="floatNumericRange"
             validate:floatminNumber="0.1"
-            validate:floatmaxNumber="5.0"
+            validate:floatmaxNumber="12.0"
             android:defaultValue="3.0"
             android:selectAllOnFocus="true"
             android:singleLine="true"


### PR DESCRIPTION
Fix reading the `min_5m_carbimpact` that returned always 0 since merging SMB to dev. (Also for AMA, where it really is used in `determine_basal`).

Also allow to set it higher than 5 as the default already is 8.