### PR TITLE
Fixed typo: Temorär -> Temporär

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -686,7 +686,7 @@
     <string name="shortgramm">g</string>
     <string name="shortkilojoul">kJ</string>
     <string name="shortenergy">En</string>
-    <string name="shortprotein">Pr</string>
+    <string name="shortprotein">Ew</string>
     <string name="shortfat">Fat</string>
     <string name="urgent_alarm">Wichtiger Alarm</string>
     <string name="info">INFO</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -189,8 +189,8 @@
     <string name="absolute">Absolut</string>
     <string name="smscommunicator_bolusfailed">Bolus fehlgeschlagen</string>
     <string name="canceltemp">TBR abbrechen</string>
-    <string name="careportal_temporarytarget">Temoräres Ziel</string>
-    <string name="careportal_temporarytargetcancel">Temoräres Ziel abbrechen</string>
+    <string name="careportal_temporarytarget">Temporäres Ziel</string>
+    <string name="careportal_temporarytargetcancel">Temporäres Ziel abbrechen</string>
     <string name="comment">Kommentar</string>
     <string name="connected">Verbunden</string>
     <string name="connecting">Verbinden</string>


### PR DESCRIPTION
Fixed a typo in the German translation.