### PR TITLE
Remove EventNewBg.isNew().

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
@@ -240,7 +240,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
             log.error("Unhandled exception", e);
         }
         VirtualPumpPlugin.setFakingStatus(true);
-        scheduleBgChange(null, false, false); // trigger refresh
+        scheduleBgChange(null, false); // trigger refresh
         scheduleTemporaryBasalChange();
         scheduleTreatmentChange(null);
         scheduleExtendedBolusChange();
@@ -373,7 +373,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
             if (old == null) {
                 getDaoBgReadings().create(bgReading);
                 log.debug("BG: New record from: " + from + " " + bgReading.toString());
-                scheduleBgChange(bgReading, true, isFromActiveBgSource);
+                scheduleBgChange(bgReading, isFromActiveBgSource);
                 return true;
             }
             if (!old.isEqual(bgReading)) {
@@ -381,7 +381,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
                 old.copyFrom(bgReading);
                 getDaoBgReadings().update(old);
                 log.debug("BG: Updating record from: " + from + " New data: " + old.toString());
-                scheduleBgChange(bgReading, false, isFromActiveBgSource);
+                scheduleBgChange(bgReading, isFromActiveBgSource);
                 return false;
             }
         } catch (SQLException e) {
@@ -399,11 +399,11 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
         }
     }
 
-    private static void scheduleBgChange(@Nullable final BgReading bgReading, boolean isNew, boolean isFromActiveBgSource) {
+    private static void scheduleBgChange(@Nullable final BgReading bgReading, boolean isFromActiveBgSource) {
         class PostRunnable implements Runnable {
             public void run() {
                 log.debug("Firing EventNewBg");
-                MainApp.bus().post(new EventNewBG(bgReading, isNew, isFromActiveBgSource));
+                MainApp.bus().post(new EventNewBG(bgReading, isFromActiveBgSource));
                 scheduledBgPost = null;
             }
         }

--- a/app/src/main/java/info/nightscout/androidaps/events/EventNewBG.java
+++ b/app/src/main/java/info/nightscout/androidaps/events/EventNewBG.java
@@ -10,7 +10,6 @@ import info.nightscout.androidaps.db.BgReading;
 public class EventNewBG extends EventLoop {
     @Nullable
     public final BgReading bgReading;
-    public final boolean isNew;
     public final boolean isFromActiveBgSource;
 
     /** Whether the BgReading is current (enough to use for treatment decisions). */
@@ -18,9 +17,8 @@ public class EventNewBG extends EventLoop {
         return bgReading != null && bgReading.date + 9 * 60 * 1000 > System.currentTimeMillis();
     }
 
-    public EventNewBG(@Nullable BgReading bgReading, boolean isNew, boolean isFromActiveBgSource) {
+    public EventNewBG(@Nullable BgReading bgReading, boolean isFromActiveBgSource) {
         this.bgReading = bgReading;
-        this.isNew = isNew;
         this.isFromActiveBgSource = isFromActiveBgSource;
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
@@ -164,7 +164,7 @@ public class LoopPlugin implements PluginBase {
             return;
 
         EventNewBG bgEv = (EventNewBG) ev.cause;
-        if (bgEv.isNew && bgEv.isFromActiveBgSource && bgEv.isCurrent()) {
+        if (bgEv.isFromActiveBgSource && bgEv.isCurrent()) {
             invoke("New BG", true);
         }
     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
@@ -142,7 +142,7 @@ public class WizardDialog extends DialogFragment implements OnClickListener, Com
 
     @Subscribe
     public void onStatusEvent(final EventNewBG e) {
-        if (e.isFromActiveBgSource && e.isNew && e.isCurrent()) {
+        if (e.isFromActiveBgSource && e.isCurrent()) {
             Activity activity = getActivity();
             if (activity != null)
                 activity.runOnUiThread(new Runnable() {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Persistentnotification/PersistentNotificationPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Persistentnotification/PersistentNotificationPlugin.java
@@ -255,7 +255,7 @@ public class PersistentNotificationPlugin implements PluginBase {
 
     @Subscribe
     public void onStatusEvent(final EventNewBG ev) {
-        if (ev.isFromActiveBgSource && ev.isNew && ev.isCurrent())
+        if (ev.isFromActiveBgSource && ev.isCurrent())
             updateNotification();
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/XDripStatusline/StatuslinePlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/XDripStatusline/StatuslinePlugin.java
@@ -235,7 +235,7 @@ public class StatuslinePlugin implements PluginBase {
 
     @Subscribe
     public void onStatusEvent(final EventNewBG ev) {
-        if (ev.isFromActiveBgSource && ev.isNew && ev.isCurrent())
+        if (ev.isFromActiveBgSource && ev.isCurrent())
             sendStatus();
     }
 


### PR DESCRIPTION
If a local BG source produces a new reading that is sent to NS, the
same reading is retrieved from NS and might be processed before
the local value is. That leads to the NS value creating a new
record, but since it's not the active BG source it doesn't trigger
a loop run. When the local value is processed it doesn't trigger a
loop run either since it wasn't a value.

This commit therefore removes the isNew field. Consumers query
isFromActiveBgSource() and isCurrent() as neede, which should be
enough.

Fixes #782, #783.