### PR TITLE
xdrip plugin - advancedFilteringSupported in eng mode

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/SourceXdrip/SourceXdripPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/SourceXdrip/SourceXdripPlugin.java
@@ -86,6 +86,6 @@ public class SourceXdripPlugin implements PluginBase, BgSourceInterface {
 
     @Override
     public boolean advancedFilteringSupported() {
-        return false;
+         return MainApp.engineeringMode;
     }
 }


### PR DESCRIPTION
xDrip+ can act as G4 Receiver, it also calculates noise lever. Using it with caution should be allowed in eng. mode with all smb modes.