### PR TITLE
Fix re-enabling the loop plugin from overview. Fixes #861.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/data/QuickWizardEntry.java
+++ b/app/src/main/java/info/nightscout/androidaps/data/QuickWizardEntry.java
@@ -11,7 +11,6 @@ import info.nightscout.androidaps.R;
 import info.nightscout.androidaps.db.BgReading;
 import info.nightscout.androidaps.db.TempTarget;
 import info.nightscout.androidaps.interfaces.TreatmentsInterface;
-import info.nightscout.androidaps.plugins.ConfigBuilder.ConfigBuilderPlugin;
 import info.nightscout.androidaps.plugins.IobCobCalculator.AutosensData;
 import info.nightscout.androidaps.plugins.IobCobCalculator.IobCobCalculatorPlugin;
 import info.nightscout.androidaps.plugins.Loop.LoopPlugin;
@@ -119,8 +118,8 @@ public class QuickWizardEntry {
         if (useSuperBolus() == YES && SP.getBoolean(R.string.key_usesuperbolus, false)) {
             superBolus = true;
         }
-        final LoopPlugin activeloop = ConfigBuilderPlugin.getActiveLoop();
-        if (activeloop != null && activeloop.isEnabled(activeloop.getType()) && activeloop.isSuperBolus())
+        final LoopPlugin loopPlugin = LoopPlugin.getPlugin();
+        if (loopPlugin.isEnabled(loopPlugin.getType()) && loopPlugin.isSuperBolus())
             superBolus = false;
 
         // Trend

--- a/app/src/main/java/info/nightscout/androidaps/plugins/ConfigBuilder/ConfigBuilderPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/ConfigBuilder/ConfigBuilderPlugin.java
@@ -264,6 +264,7 @@ public class ConfigBuilderPlugin extends PluginBase {
         return activeAPS;
     }
 
+    @Nullable
     public static LoopPlugin getActiveLoop() {
         return activeLoop;
     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/ConfigBuilder/ConfigBuilderPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/ConfigBuilder/ConfigBuilderPlugin.java
@@ -264,11 +264,6 @@ public class ConfigBuilderPlugin extends PluginBase {
         return activeAPS;
     }
 
-    @Nullable
-    public static LoopPlugin getActiveLoop() {
-        return activeLoop;
-    }
-
     public static PumpInterface getActivePump() {
         return activePump;
     }
@@ -622,7 +617,7 @@ public class ConfigBuilderPlugin extends PluginBase {
     }
 
     public void disconnectPump(int durationInMinutes, Profile profile) {
-        getActiveLoop().disconnectTo(System.currentTimeMillis() + durationInMinutes * 60 * 1000L);
+        LoopPlugin.getPlugin().disconnectTo(System.currentTimeMillis() + durationInMinutes * 60 * 1000L);
         getCommandQueue().tempBasalPercent(0, durationInMinutes, true, profile, new Callback() {
             @Override
             public void run() {
@@ -645,7 +640,7 @@ public class ConfigBuilderPlugin extends PluginBase {
     }
 
     public void suspendLoop(int durationInMinutes) {
-        getActiveLoop().suspendTo(System.currentTimeMillis() + durationInMinutes * 60 * 1000);
+        LoopPlugin.getPlugin().suspendTo(System.currentTimeMillis() + durationInMinutes * 60 * 1000);
         getCommandQueue().cancelTempBasal(true, new Callback() {
             @Override
             public void run() {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
@@ -9,6 +9,7 @@ import android.app.TaskStackBuilder;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 
 import com.crashlytics.android.answers.CustomEvent;
@@ -56,6 +57,7 @@ public class LoopPlugin extends PluginBase {
 
     protected static LoopPlugin loopPlugin;
 
+    @NonNull
     public static LoopPlugin getPlugin() {
         if (loopPlugin == null) {
             loopPlugin = new LoopPlugin();

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
@@ -53,6 +53,7 @@ import info.nightscout.androidaps.events.EventFeatureRunning;
 import info.nightscout.androidaps.events.EventNewBG;
 import info.nightscout.androidaps.events.EventRefreshOverview;
 import info.nightscout.androidaps.interfaces.Constraint;
+import info.nightscout.androidaps.interfaces.PluginType;
 import info.nightscout.androidaps.plugins.ConfigBuilder.ConfigBuilderPlugin;
 import info.nightscout.androidaps.plugins.IobCobCalculator.AutosensData;
 import info.nightscout.androidaps.plugins.IobCobCalculator.IobCobCalculatorPlugin;
@@ -334,9 +335,9 @@ public class WizardDialog extends DialogFragment implements OnClickListener, Com
                                 accepted = true;
                                 if (finalInsulinAfterConstraints > 0 || finalCarbsAfterConstraints > 0) {
                                     if (useSuperBolus) {
-                                        final LoopPlugin activeloop = ConfigBuilderPlugin.getActiveLoop();
-                                        if (activeloop != null) {
-                                            activeloop.superBolusTo(System.currentTimeMillis() + 2 * 60L * 60 * 1000);
+                                        final LoopPlugin loopPlugin = LoopPlugin.getPlugin();
+                                        if (loopPlugin.isEnabled(PluginType.LOOP)) {
+                                            loopPlugin.superBolusTo(System.currentTimeMillis() + 2 * 60L * 60 * 1000);
                                             MainApp.bus().post(new EventRefreshOverview("WizardDialog"));
                                         }
                                         ConfigBuilderPlugin.getCommandQueue().tempBasalPercent(0, 120, true, profile, new Callback() {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/SmsCommunicator/SmsCommunicatorPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/SmsCommunicator/SmsCommunicatorPlugin.java
@@ -279,8 +279,7 @@ public class SmsCommunicatorPlugin extends PluginBase {
                                 FabricPrivacy.getInstance().logCustom(new CustomEvent("SMS_Loop_Status"));
                                 break;
                             case "RESUME":
-                                final LoopPlugin activeloop = ConfigBuilderPlugin.getActiveLoop();
-                                activeloop.suspendTo(0);
+                                LoopPlugin.getPlugin().suspendTo(0);
                                 MainApp.bus().post(new EventRefreshOverview("SMS_LOOP_RESUME"));
                                 NSUpload.uploadOpenAPSOffline(0);
                                 reply = MainApp.sResources.getString(R.string.smscommunicator_loopresumed);
@@ -517,8 +516,7 @@ public class SmsCommunicatorPlugin extends PluginBase {
                             @Override
                             public void run() {
                                 if (result.success) {
-                                    final LoopPlugin activeloop = ConfigBuilderPlugin.getActiveLoop();
-                                    activeloop.suspendTo(System.currentTimeMillis() + suspendWaitingForConfirmation.duration * 60L * 1000);
+                                    LoopPlugin.getPlugin().suspendTo(System.currentTimeMillis() + suspendWaitingForConfirmation.duration * 60L * 1000);
                                     NSUpload.uploadOpenAPSOffline(suspendWaitingForConfirmation.duration * 60);
                                     MainApp.bus().post(new EventRefreshOverview("SMS_LOOP_SUSPENDED"));
                                     String reply = MainApp.sResources.getString(R.string.smscommunicator_loopsuspended) + " " +

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Wear/ActionStringHandler.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Wear/ActionStringHandler.java
@@ -441,21 +441,21 @@ public class ActionStringHandler {
     private static String getLoopStatus() {
         String ret = "";
         // decide if enabled/disabled closed/open; what Plugin as APS?
-        final LoopPlugin activeloop = MainApp.getConfigBuilder().getActiveLoop();
-        if (activeloop != null && activeloop.isEnabled(activeloop.getType())) {
+        final LoopPlugin loopPlugin = LoopPlugin.getPlugin();
+        if (loopPlugin.isEnabled(loopPlugin.getType())) {
             if (MainApp.getConstraintChecker().isClosedLoopAllowed().value()) {
                 ret += "CLOSED LOOP\n";
             } else {
                 ret += "OPEN LOOP\n";
             }
-            final APSInterface aps = MainApp.getConfigBuilder().getActiveAPS();
+            final APSInterface aps = ConfigBuilderPlugin.getActiveAPS();
             ret += "APS: " + ((aps == null) ? "NO APS SELECTED!" : ((PluginBase) aps).getName());
-            if (activeloop.lastRun != null) {
-                if (activeloop.lastRun.lastAPSRun != null)
-                    ret += "\nLast Run: " + DateUtil.timeString(activeloop.lastRun.lastAPSRun);
+            if (LoopPlugin.lastRun != null) {
+                if (LoopPlugin.lastRun.lastAPSRun != null)
+                    ret += "\nLast Run: " + DateUtil.timeString(LoopPlugin.lastRun.lastAPSRun);
 
-                if (activeloop.lastRun.lastEnact != null)
-                    ret += "\nLast Enact: " + DateUtil.timeString(activeloop.lastRun.lastEnact);
+                if (LoopPlugin.lastRun.lastEnact != null)
+                    ret += "\nLast Enact: " + DateUtil.timeString(LoopPlugin.lastRun.lastEnact);
 
             }
 
@@ -502,7 +502,7 @@ public class ActionStringHandler {
             return "No profile set :(";
         }
 
-        APSInterface usedAPS = MainApp.getConfigBuilder().getActiveAPS();
+        APSInterface usedAPS = ConfigBuilderPlugin.getActiveAPS();
         if (usedAPS == null) {
             return "No active APS :(!";
         }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Wear/WearPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Wear/WearPlugin.java
@@ -140,11 +140,7 @@ public class WearPlugin extends PluginBase {
 
     @Subscribe
     public void onStatusEvent(final EventRefreshOverview ev) {
-
-        LoopPlugin activeloop = MainApp.getConfigBuilder().getActiveLoop();
-        if (activeloop == null) return;
-
-        if (WatchUpdaterService.shouldReportLoopStatus(activeloop.isEnabled(PluginType.LOOP))) {
+        if (WatchUpdaterService.shouldReportLoopStatus(LoopPlugin.getPlugin().isEnabled(PluginType.LOOP))) {
             sendDataToWatch(true, false, false);
         }
     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Wear/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Wear/wearintegration/WatchUpdaterService.java
@@ -666,12 +666,12 @@ public class WatchUpdaterService extends WearableListenerService implements
             return status;
         }
 
-        LoopPlugin activeloop = MainApp.getConfigBuilder().getActiveLoop();
+        LoopPlugin activeloop = LoopPlugin.getPlugin();
 
-        if (activeloop != null && !activeloop.isEnabled(PluginType.LOOP)) {
+        if (!activeloop.isEnabled(PluginType.LOOP)) {
             status += getString(R.string.disabledloop) + "\n";
             lastLoopStatus = false;
-        } else if (activeloop != null && activeloop.isEnabled(PluginType.LOOP)) {
+        } else {
             lastLoopStatus = true;
         }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/XDripStatusline/StatuslinePlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/XDripStatusline/StatuslinePlugin.java
@@ -108,12 +108,12 @@ public class StatuslinePlugin extends PluginBase {
     @NonNull
     private String buildStatusString(Profile profile) {
         String status = "";
-        LoopPlugin activeloop = ConfigBuilderPlugin.getActiveLoop();
+        LoopPlugin loopPlugin = LoopPlugin.getPlugin();
 
-        if (activeloop != null && !activeloop.isEnabled(PluginType.LOOP)) {
+        if (!loopPlugin.isEnabled(PluginType.LOOP)) {
             status += ctx.getString(R.string.disabledloop) + "\n";
             lastLoopStatus = false;
-        } else if (activeloop != null && activeloop.isEnabled(PluginType.LOOP)) {
+        } else if (loopPlugin.isEnabled(PluginType.LOOP)) {
             lastLoopStatus = true;
         }
 
@@ -179,13 +179,8 @@ public class StatuslinePlugin extends PluginBase {
 
     @Subscribe
     public void onStatusEvent(final EventRefreshOverview ev) {
-
         //Filter events where loop is (de)activated
-
-        LoopPlugin activeloop = ConfigBuilderPlugin.getActiveLoop();
-        if (activeloop == null) return;
-
-        if ((lastLoopStatus != activeloop.isEnabled(PluginType.LOOP))) {
+        if ((lastLoopStatus != LoopPlugin.getPlugin().isEnabled(PluginType.LOOP))) {
             sendStatus();
         }
     }

--- a/app/src/main/java/info/nightscout/utils/LocalAlertUtils.java
+++ b/app/src/main/java/info/nightscout/utils/LocalAlertUtils.java
@@ -13,6 +13,7 @@ import info.nightscout.androidaps.db.BgReading;
 import info.nightscout.androidaps.db.DatabaseHelper;
 import info.nightscout.androidaps.interfaces.PumpInterface;
 import info.nightscout.androidaps.plugins.ConfigBuilder.ConfigBuilderPlugin;
+import info.nightscout.androidaps.plugins.Loop.LoopPlugin;
 import info.nightscout.androidaps.plugins.Overview.events.EventNewNotification;
 import info.nightscout.androidaps.plugins.Overview.notifications.Notification;
 import info.nightscout.androidaps.receivers.KeepAliveReceiver;
@@ -38,7 +39,7 @@ public class LocalAlertUtils {
         boolean nextAlarmOccurrenceReached = SP.getLong("nextPumpDisconnectedAlarm", 0L) < System.currentTimeMillis();
 
         if (Config.APS && SP.getBoolean(MainApp.sResources.getString(R.string.key_enable_pump_unreachable_alert), true)
-                && isStatusOutdated && alarmTimeoutExpired && nextAlarmOccurrenceReached && !ConfigBuilderPlugin.getActiveLoop().isDisconnected()) {
+                && isStatusOutdated && alarmTimeoutExpired && nextAlarmOccurrenceReached && !LoopPlugin.getPlugin().isDisconnected()) {
             log.debug("Generating pump unreachable alarm. lastConnection: " + DateUtil.dateAndTimeString(lastConnection) + " isStatusOutdated: " + isStatusOutdated);
             Notification n = new Notification(Notification.PUMP_UNREACHABLE, MainApp.sResources.getString(R.string.pump_unreachable), Notification.URGENT);
             n.soundId = R.raw.alarm;


### PR DESCRIPTION
Note that enabling a loop plugin is hardcoded against the only
impl currently available LoopPlugin. Support for multiple loop
plugins is incomplete (and not needed at this point), since
there's no LoopInterface, but immediately LoopPlugin (as compared
to APSInterface with OpenAPS* impls).
When adding support, the last activated loop plugin must be remembered
so the correct one is re-enabled.