### PR TITLE
More generous values for colored iage warnings (careportal)

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Careportal/CareportalFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Careportal/CareportalFragment.java
@@ -216,8 +216,8 @@ public class CareportalFragment extends SubscriberFragment implements View.OnCli
                         CareportalEvent careportalEvent;
                         NSSettingsStatus nsSettings = new NSSettingsStatus().getInstance();
 
-                        double iageUrgent = nsSettings.getExtendedWarnValue("iage", "urgent", 72);
-                        double iageWarn = nsSettings.getExtendedWarnValue("iage", "warn", 48);
+                        double iageUrgent = nsSettings.getExtendedWarnValue("iage", "urgent", 86);
+                        double iageWarn = nsSettings.getExtendedWarnValue("iage", "warn", 72);
                         double cageUrgent = nsSettings.getExtendedWarnValue("cage", "urgent", 72);
                         double cageWarn = nsSettings.getExtendedWarnValue("cage", "warn", 48);
                         double sageUrgent = nsSettings.getExtendedWarnValue("sage", "urgent", 166);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Careportal/CareportalFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Careportal/CareportalFragment.java
@@ -216,7 +216,7 @@ public class CareportalFragment extends SubscriberFragment implements View.OnCli
                         CareportalEvent careportalEvent;
                         NSSettingsStatus nsSettings = new NSSettingsStatus().getInstance();
 
-                        double iageUrgent = nsSettings.getExtendedWarnValue("iage", "urgent", 86);
+                        double iageUrgent = nsSettings.getExtendedWarnValue("iage", "urgent", 96);
                         double iageWarn = nsSettings.getExtendedWarnValue("iage", "warn", 72);
                         double cageUrgent = nsSettings.getExtendedWarnValue("cage", "urgent", 72);
                         double cageWarn = nsSettings.getExtendedWarnValue("cage", "warn", 48);


### PR DESCRIPTION
Normaly Insulin should be stable at least 4-5 days. So I think a warning after two days and a red alarm after three is two early. I changed the default values to 72 hours for the yellow and 86 hours for the red warning.