### PR TITLE
Enforce TBRs on enforceNew

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/queue/CommandQueue.java
+++ b/app/src/main/java/info/nightscout/androidaps/queue/CommandQueue.java
@@ -205,7 +205,7 @@ public class CommandQueue {
 
     // returns true if command is queued
     public boolean tempBasalAbsolute(double absoluteRate, int durationInMinutes, boolean enforceNew, Profile profile, Callback callback) {
-        if (isRunning(Command.CommandType.TEMPBASAL)) {
+        if (!enforceNew && isRunning(Command.CommandType.TEMPBASAL)) {
             if (callback != null)
                 callback.result(executingNowError()).run();
             return false;
@@ -226,7 +226,7 @@ public class CommandQueue {
 
     // returns true if command is queued
     public boolean tempBasalPercent(Integer percent, int durationInMinutes, boolean enforceNew, Profile profile, Callback callback) {
-        if (isRunning(Command.CommandType.TEMPBASAL)) {
+        if (!enforceNew && isRunning(Command.CommandType.TEMPBASAL)) {
             if (callback != null)
                 callback.result(executingNowError()).run();
             return false;
@@ -268,7 +268,7 @@ public class CommandQueue {
 
     // returns true if command is queued
     public boolean cancelTempBasal(boolean enforceNew, Callback callback) {
-        if (isRunning(Command.CommandType.TEMPBASAL)) {
+        if (!enforceNew && isRunning(Command.CommandType.TEMPBASAL)) {
             if (callback != null)
                 callback.result(executingNowError()).run();
             return false;


### PR DESCRIPTION
Accept and queue TBR Commands if they have the flag `enforceNew` even though a TBR command is running. (E.G. Superbolus or Disconnect while a Loop-TBR is being enacted. On the Combo the chances are higher of a conincidence as it takes a while to execute a TBR command)