### PR TITLE
Don't loop with old BG value, don't loop twice for the same value.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
@@ -29,6 +29,7 @@ import info.nightscout.androidaps.data.Profile;
 import info.nightscout.androidaps.data.PumpEnactResult;
 import info.nightscout.androidaps.db.BgReading;
 import info.nightscout.androidaps.db.DatabaseHelper;
+import info.nightscout.androidaps.events.Event;
 import info.nightscout.androidaps.events.EventNewBG;
 import info.nightscout.androidaps.events.EventTreatmentChange;
 import info.nightscout.androidaps.interfaces.APSInterface;
@@ -136,6 +137,15 @@ public class LoopPlugin extends PluginBase {
         }
     }
 
+    /**
+     * This method is triggered once autosens calculation has completed, so the LoopPlugin
+     * has current data to work with. However, autosens calculation can be triggered by multiple
+     * sources and currently only a new BG should trigger a loop run. Hence we return early if
+     * the event causing the calculation is not EventNewBg.
+     *
+     *  Callers of {@link info.nightscout.androidaps.plugins.IobCobCalculator.IobCobCalculatorPlugin#runCalculation(String, long, boolean, Event)}
+     *  are sources triggering a calculation which triggers this method upon completion.
+     */
     @Subscribe
     public void onStatusEvent(final EventAutosensCalculationFinished ev) {
         if (!(ev.cause instanceof EventNewBG)) {


### PR DESCRIPTION
Loop is potentially triggered twice when BG reading sent to NS comes back.
This should also deal with backfilled data coming in, since any previous
reading will be older than 9m, for which DatabaseHelper.actualBg()
returns null.

The previous approach to solve multiple invocations for the same value
added a isNew flag to EventNewBG, but since
DatabaseHelper.scheduleBgChange() drops excessive updates the event
carrying that flag is not guarantued to be delivered, resulting in
missed loop invocations. The approach taken now lets the receiver
of the event fully decide how to deal with it.

Should fix, or at least improve, #901, #671.