### PR TITLE
Add IobCobCalculatorPlugin.getCobInfo().

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/data/QuickWizardEntry.java
+++ b/app/src/main/java/info/nightscout/androidaps/data/QuickWizardEntry.java
@@ -11,7 +11,7 @@ import info.nightscout.androidaps.R;
 import info.nightscout.androidaps.db.BgReading;
 import info.nightscout.androidaps.db.TempTarget;
 import info.nightscout.androidaps.interfaces.TreatmentsInterface;
-import info.nightscout.androidaps.plugins.IobCobCalculator.AutosensData;
+import info.nightscout.androidaps.plugins.IobCobCalculator.CobInfo;
 import info.nightscout.androidaps.plugins.IobCobCalculator.IobCobCalculatorPlugin;
 import info.nightscout.androidaps.plugins.Loop.LoopPlugin;
 import info.nightscout.androidaps.plugins.Treatments.TreatmentsPlugin;
@@ -79,14 +79,10 @@ public class QuickWizardEntry {
 
         // COB
         double cob = 0d;
-        AutosensData autosensData;
-        if (_synchronized)
-            autosensData = IobCobCalculatorPlugin.getPlugin().getLastAutosensDataSynchronized("QuickWizard COB");
-        else
-            autosensData = IobCobCalculatorPlugin.getPlugin().getLastAutosensData("QuickWizard COB");
-
-        if (autosensData != null && useCOB() == YES) {
-            cob = autosensData.cob;
+        if (useCOB() == YES) {
+            CobInfo cobInfo = IobCobCalculatorPlugin.getPlugin().getCobInfo(_synchronized, "QuickWizard COB");
+            if (cobInfo.displayCob != null)
+                cob = cobInfo.displayCob;
         }
 
         // Temp target

--- a/app/src/main/java/info/nightscout/androidaps/plugins/IobCobCalculator/CobInfo.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/IobCobCalculator/CobInfo.java
@@ -1,0 +1,15 @@
+package info.nightscout.androidaps.plugins.IobCobCalculator;
+
+import android.support.annotation.Nullable;
+
+public class CobInfo {
+    /** All COB up to now, including carbs not yet processed by IobCob calculation. */
+    @Nullable
+    public final Double displayCob;
+    public final double futureCarbs;
+
+    public CobInfo(@Nullable Double displayCob, double futureCarbs) {
+        this.displayCob = displayCob;
+        this.futureCarbs = futureCarbs;
+    }
+}

--- a/app/src/main/java/info/nightscout/androidaps/plugins/IobCobCalculator/IobCobCalculatorPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/IobCobCalculator/IobCobCalculatorPlugin.java
@@ -34,8 +34,11 @@ import info.nightscout.androidaps.interfaces.PluginType;
 import info.nightscout.androidaps.plugins.ConfigBuilder.ConfigBuilderPlugin;
 import info.nightscout.androidaps.plugins.IobCobCalculator.events.EventNewHistoryData;
 import info.nightscout.androidaps.plugins.OpenAPSSMB.OpenAPSSMBPlugin;
+import info.nightscout.androidaps.plugins.Treatments.Treatment;
 import info.nightscout.androidaps.plugins.Treatments.TreatmentsPlugin;
 import info.nightscout.utils.DateUtil;
+
+import static info.nightscout.utils.DateUtil.now;
 
 /**
  * Created by mike on 24.04.2017.
@@ -401,6 +404,28 @@ public class IobCobCalculatorPlugin extends PluginBase {
         }
     }
 
+    public CobInfo getCobInfo(boolean _synchronized, String reason) {
+        AutosensData autosensData = _synchronized ? getLastAutosensDataSynchronized(reason) : getLastAutosensData(reason);
+        Double displayCob = null;
+        double futureCarbs = 0;
+        long now = now();
+        List<Treatment> treatments = TreatmentsPlugin.getPlugin().getTreatmentsFromHistory();
+
+        if (autosensData != null) {
+            displayCob = autosensData.cob;
+            for (Treatment treatment : treatments) {
+                if (IobCobCalculatorPlugin.roundUpTime(treatment.date) > autosensData.time && treatment.date < now && treatment.carbs > 0) {
+                    displayCob += treatment.carbs;
+                }
+            }
+        }
+        for (Treatment treatment : treatments) {
+            if (treatment.date > now && treatment.carbs > 0) {
+                futureCarbs += treatment.carbs;
+            }
+        }
+        return new CobInfo(displayCob, futureCarbs);
+    }
 
     @Nullable
     public AutosensData getLastAutosensData(String reason) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/IobCobCalculator/IobCobCalculatorPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/IobCobCalculator/IobCobCalculatorPlugin.java
@@ -415,7 +415,7 @@ public class IobCobCalculatorPlugin extends PluginBase {
             displayCob = autosensData.cob;
             for (Treatment treatment : treatments) {
                 if (IobCobCalculatorPlugin.roundUpTime(treatment.date) > IobCobCalculatorPlugin.roundUpTime(autosensData.time)
-                        && treatment.date < now && treatment.carbs > 0) {
+                        && treatment.date <= now && treatment.carbs > 0) {
                     displayCob += treatment.carbs;
                 }
             }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/IobCobCalculator/IobCobCalculatorPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/IobCobCalculator/IobCobCalculatorPlugin.java
@@ -414,7 +414,8 @@ public class IobCobCalculatorPlugin extends PluginBase {
         if (autosensData != null) {
             displayCob = autosensData.cob;
             for (Treatment treatment : treatments) {
-                if (IobCobCalculatorPlugin.roundUpTime(treatment.date) > autosensData.time && treatment.date < now && treatment.carbs > 0) {
+                if (IobCobCalculatorPlugin.roundUpTime(treatment.date) > IobCobCalculatorPlugin.roundUpTime(autosensData.time)
+                        && treatment.date < now && treatment.carbs > 0) {
                     displayCob += treatment.carbs;
                 }
             }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
@@ -489,7 +489,7 @@ public class WizardDialog extends DialogFragment implements OnClickListener, Com
         Double c_cob = 0d;
         if (cobCheckbox.isChecked()) {
             CobInfo cobInfo = IobCobCalculatorPlugin.getPlugin().getCobInfo(false, "Wizard COB");
-            if (cobInfo != null)
+            if (cobInfo != null && cobInfo.displayCob != null)
                 c_cob = cobInfo.displayCob;
         }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
@@ -56,7 +56,7 @@ import info.nightscout.androidaps.events.EventRefreshOverview;
 import info.nightscout.androidaps.interfaces.Constraint;
 import info.nightscout.androidaps.interfaces.PluginType;
 import info.nightscout.androidaps.plugins.ConfigBuilder.ConfigBuilderPlugin;
-import info.nightscout.androidaps.plugins.IobCobCalculator.AutosensData;
+import info.nightscout.androidaps.plugins.IobCobCalculator.CobInfo;
 import info.nightscout.androidaps.plugins.IobCobCalculator.IobCobCalculatorPlugin;
 import info.nightscout.androidaps.plugins.IobCobCalculator.events.EventAutosensCalculationFinished;
 import info.nightscout.androidaps.plugins.Loop.LoopPlugin;
@@ -488,11 +488,9 @@ public class WizardDialog extends DialogFragment implements OnClickListener, Com
         // COB
         Double c_cob = 0d;
         if (cobCheckbox.isChecked()) {
-            AutosensData autosensData = IobCobCalculatorPlugin.getPlugin().getLastAutosensData("Wizard COB");
-
-            if (autosensData != null) {
-                c_cob = autosensData.cob;
-            }
+            CobInfo cobInfo = IobCobCalculatorPlugin.getPlugin().getCobInfo(false, "Wizard COB");
+            if (cobInfo != null)
+                c_cob = cobInfo.displayCob;
         }
 
         BolusWizard wizard = new BolusWizard();

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/OverviewFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/OverviewFragment.java
@@ -88,7 +88,7 @@ import info.nightscout.androidaps.plugins.Careportal.Dialogs.NewNSTreatmentDialo
 import info.nightscout.androidaps.plugins.Careportal.OptionsToShow;
 import info.nightscout.androidaps.plugins.ConfigBuilder.ConfigBuilderPlugin;
 import info.nightscout.androidaps.plugins.ConstraintsObjectives.ObjectivesPlugin;
-import info.nightscout.androidaps.plugins.IobCobCalculator.AutosensData;
+import info.nightscout.androidaps.plugins.IobCobCalculator.CobInfo;
 import info.nightscout.androidaps.plugins.IobCobCalculator.IobCobCalculatorPlugin;
 import info.nightscout.androidaps.plugins.IobCobCalculator.events.EventAutosensCalculationFinished;
 import info.nightscout.androidaps.plugins.IobCobCalculator.events.EventIobCalculationProgress;
@@ -1283,10 +1283,13 @@ public class OverviewFragment extends Fragment implements View.OnClickListener, 
 
         // cob
         if (cobView != null) { // view must not exists
-            String cobText = "";
-            AutosensData autosensData = IobCobCalculatorPlugin.getPlugin().getLastAutosensData("Overview COB");
-            if (autosensData != null)
-                cobText = (int) autosensData.cob + " g";
+            String cobText = MainApp.gs(R.string.value_unavailable_short);
+            CobInfo cobInfo = IobCobCalculatorPlugin.getPlugin().getCobInfo(false, "Overview COB");
+            if (cobInfo.displayCob != null) {
+                cobText = DecimalFormatter.to0Decimal(cobInfo.displayCob);
+                if (cobInfo.futureCarbs > 0)
+                    cobText += "(" + DecimalFormatter.to0Decimal(cobInfo.futureCarbs) + ")";
+            }
             cobView.setText(cobText);
         }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Wear/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Wear/wearintegration/WatchUpdaterService.java
@@ -37,6 +37,7 @@ import info.nightscout.androidaps.data.Profile;
 import info.nightscout.androidaps.db.BgReading;
 import info.nightscout.androidaps.db.DatabaseHelper;
 import info.nightscout.androidaps.db.TemporaryBasal;
+import info.nightscout.androidaps.plugins.IobCobCalculator.CobInfo;
 import info.nightscout.androidaps.plugins.Treatments.Treatment;
 import info.nightscout.androidaps.interfaces.PluginType;
 import info.nightscout.androidaps.interfaces.TreatmentsInterface;
@@ -718,9 +719,9 @@ public class WatchUpdaterService extends WearableListenerService implements
     private String generateCOBString() {
 
         String cobStringResult = "--";
-        AutosensData autosensData = IobCobCalculatorPlugin.getPlugin().getLastAutosensData("WatcherUpdaterService");
-        if (autosensData != null) {
-            cobStringResult = (int) autosensData.cob + "g";
+        CobInfo cobInfo = IobCobCalculatorPlugin.getPlugin().getCobInfo(false, "WatcherUpdaterService");
+        if (cobInfo.displayCob != null) {
+            cobStringResult = DecimalFormatter.to0Decimal(cobInfo.displayCob) + "g";
         }
         return cobStringResult;
     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Wear/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Wear/wearintegration/WatchUpdaterService.java
@@ -721,10 +721,11 @@ public class WatchUpdaterService extends WearableListenerService implements
         String cobStringResult = "--";
         CobInfo cobInfo = IobCobCalculatorPlugin.getPlugin().getCobInfo(false, "WatcherUpdaterService");
         if (cobInfo.displayCob != null) {
-            cobStringResult = DecimalFormatter.to0Decimal(cobInfo.displayCob) + "g";
+            cobStringResult = DecimalFormatter.to0Decimal(cobInfo.displayCob);
             if (cobInfo.futureCarbs > 0) {
-                cobStringResult += " (" + DecimalFormatter.to0Decimal(cobInfo.futureCarbs) + ")";
+                cobStringResult += "(" + DecimalFormatter.to0Decimal(cobInfo.futureCarbs) + ")";
             }
+            cobStringResult += "g";
         }
         return cobStringResult;
     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Wear/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Wear/wearintegration/WatchUpdaterService.java
@@ -722,6 +722,9 @@ public class WatchUpdaterService extends WearableListenerService implements
         CobInfo cobInfo = IobCobCalculatorPlugin.getPlugin().getCobInfo(false, "WatcherUpdaterService");
         if (cobInfo.displayCob != null) {
             cobStringResult = DecimalFormatter.to0Decimal(cobInfo.displayCob) + "g";
+            if (cobInfo.futureCarbs > 0) {
+                cobStringResult += " (" + DecimalFormatter.to0Decimal(cobInfo.futureCarbs) + ")";
+            }
         }
         return cobStringResult;
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1031,4 +1031,5 @@
     <string name="openapsama_bolussnooze_dia_divisor">Bolus snooze dia divisor</string>
     <string name="openapsama_max_daily_safety_multiplier">Max daily safety multiplier</string>
     <string name="openapsama_current_basal_safety_multiplier">Current basal safety multiplier</string>
+    <string name="value_unavailable_short">n/a</string>
 </resources>


### PR DESCRIPTION
* COB on overview is now always up-to-date and includes carbs not yet processed by IobCob calculation. 
* Same for the wizards, so that two entered meals between calculations have proper input.
* All scheduled/future carbs are displayed in brackets (if any) with COB on overview.

Roughly tested. Calculation of `displayCob` needs a check to ensure carbs aren't added which are already processed.