### PR TITLE
align failoverToMinAbsorbtionRate to cobtime

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/IobCobCalculator/AutosensData.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/IobCobCalculator/AutosensData.java
@@ -156,7 +156,7 @@ public class AutosensData implements DataPointWithLabelInterface {
 
     @Override
     public float getSize() {
-        return 1f;
+        return 0.5f;
     }
 
     @Override

--- a/app/src/main/java/info/nightscout/androidaps/plugins/IobCobCalculator/AutosensData.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/IobCobCalculator/AutosensData.java
@@ -28,6 +28,10 @@ import info.nightscout.utils.SP;
 public class AutosensData implements DataPointWithLabelInterface {
     private static Logger log = LoggerFactory.getLogger(AutosensData.class);
 
+    public void setChartTime(long chartTime) {
+        this.chartTime = chartTime;
+    }
+
     static class CarbsInPast {
         long time = 0L;
         double carbs = 0d;
@@ -52,6 +56,7 @@ public class AutosensData implements DataPointWithLabelInterface {
     }
 
     public long time = 0L;
+    long chartTime;
     public String pastSensitivity = "";
     public double deviation = 0d;
     boolean nonCarbsDeviation = false;
@@ -121,7 +126,7 @@ public class AutosensData implements DataPointWithLabelInterface {
 
     @Override
     public double getX() {
-        return time;
+        return chartTime;
     }
 
     @Override

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/graphData/GraphData.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/graphData/GraphData.java
@@ -396,7 +396,7 @@ public class GraphData {
         cobData = cobArray.toArray(cobData);
         cobSeries = new FixedLineGraphSeries<>(cobData);
         cobSeries.setDrawBackground(true);
-        cobSeries.setBackgroundColor(0xB0FFFFFF & MainApp.gc(R.color.cob)); //50%
+        cobSeries.setBackgroundColor(0x80FFFFFF & MainApp.gc(R.color.cob)); //50%
         cobSeries.setColor(MainApp.gc(R.color.cob));
         cobSeries.setThickness(3);
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/graphData/GraphData.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/graphData/GraphData.java
@@ -385,6 +385,7 @@ public class GraphData {
                 }
                 if (autosensData.failoverToMinAbsorbtionRate) {
                     autosensData.setScale(cobScale);
+                    autosensData.setChartTime(time);
                     minFailoverActiveList.add(autosensData);
                 }
             }


### PR DESCRIPTION
The time on the chart and the time of the autosensedata did not align. Autosensedata usually is earlier as the one before gets picked.

before:
![screenshot_20180426-030307](https://user-images.githubusercontent.com/9692866/39280695-0a12e8d0-4901-11e8-88ca-2e72121e33d8.png)

after:
![screenshot_20180426-031238](https://user-images.githubusercontent.com/9692866/39280745-507a46d8-4901-11e8-8243-b3ce9a96e9ff.png)
