### PR TITLE
Don't create empty future carbs records. Fixes #940.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/NewCarbsDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/NewCarbsDialog.java
@@ -403,7 +403,8 @@ public class NewCarbsDialog extends DialogFragment implements OnClickListener, C
                                     long carbTime = time + i * 15 * 60 * 1000;
                                     long smallCarbAmount = Math.round((1d * remainingCarbs) / (ticks-i));  //on last iteration (ticks-i) is 1 -> smallCarbAmount == remainingCarbs
                                     remainingCarbs -= smallCarbAmount;
-                                    createCarb(smallCarbAmount, carbTime, notes);
+                                    if (smallCarbAmount > 0)
+                                        createCarb(smallCarbAmount, carbTime, notes);
                                 }
                             }
                         }

--- a/app/src/test/java/info/nightscout/MainAppTest.java
+++ b/app/src/test/java/info/nightscout/MainAppTest.java
@@ -76,7 +76,7 @@ public class MainAppTest {
         if (Config.NSCLIENT || Config.G5UPLOADER)
             expected = 1; // VirtualPump only
         else
-            expected = 6;
+            expected = 7;
         Assert.assertEquals(expected, mainApp.getSpecificPluginsList(PluginType.PUMP).size());
     }
 
@@ -87,7 +87,7 @@ public class MainAppTest {
         if (Config.NSCLIENT || Config.G5UPLOADER)
             expected = 1; // VirtualPump only
         else
-            expected = 6;
+            expected = 7;
         Assert.assertEquals(expected, mainApp.getSpecificPluginsVisibleInList(PluginType.PUMP).size());
     }
 
@@ -98,7 +98,7 @@ public class MainAppTest {
         if (Config.NSCLIENT || Config.G5UPLOADER)
             expected = 1; // VirtualPump only
         else
-            expected = 6;
+            expected = 7;
         Assert.assertEquals(expected, mainApp.getSpecificPluginsListByInterface(PumpInterface.class).size());
     }
 
@@ -109,7 +109,7 @@ public class MainAppTest {
         if (Config.NSCLIENT || Config.G5UPLOADER)
             expected = 1; // VirtualPump only
         else
-            expected = 6;
+            expected = 7;
         Assert.assertEquals(expected, mainApp.getSpecificPluginsVisibleInListByInterface(PumpInterface.class, PluginType.PUMP).size());
     }
 


### PR DESCRIPTION
When very few carbs are stretched out (e.g. 10g over 4h), there are
gaps, so that 1g is generated only every 30m. Don't create empty
records in between.