### PR TITLE
Brighter green for "treatment active" for better readability.

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -52,7 +52,7 @@
     <color name="colorProfileSwitchButton">#ca77dd</color>
 
     <color name="colorScheduled">#de7550</color>
-    <color name="colorActive">#1b5e20</color>
+    <color name="colorActive">#25912e</color>
 
     <color name="loopenabled">#47c8ff</color>
     <color name="loopdisabled">#FFDD7792</color>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1732305/39524681-00693488-4e1a-11e8-9b13-9e3d8215640a.png)
After:
![image](https://user-images.githubusercontent.com/1732305/39524695-0b8a43b6-4e1a-11e8-8e34-28fc66137357.png)
(just the color)