### PR TITLE
eCarb also for small watches

### DIFF
--- a/wear/src/main/java/info/nightscout/androidaps/interaction/actions/ECarbActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/actions/ECarbActivity.java
@@ -81,7 +81,7 @@ public class ECarbActivity extends ViewSelectorActivity {
                     def = SafeParse.stringToDouble(editStartTime.editText.getText().toString());
                 }
                 editStartTime = new PlusMinusEditText(view, R.id.amountfield, R.id.plusbutton, R.id.minusbutton, def, 0d, 300d, 15d, new DecimalFormat("0"), false);
-                setLabelToPlusMinusView(view, "start [min]");
+                setLabelToPlusMinusView(view, "start [m]");
                 container.addView(view);
                 return view;
             } else if(col == 2){
@@ -91,7 +91,7 @@ public class ECarbActivity extends ViewSelectorActivity {
                     def = SafeParse.stringToDouble(editDuration.editText.getText().toString());
                 }
                 editDuration = new PlusMinusEditText(view, R.id.amountfield, R.id.plusbutton, R.id.minusbutton, def, 0d, 8d, 1d, new DecimalFormat("0"), false);
-                setLabelToPlusMinusView(view, "duration [h]");
+                setLabelToPlusMinusView(view, "dur. [h]");
                 container.addView(view);
                 return view;
             } else {

--- a/wear/src/main/res/layout/action_editplusminus_item.xml
+++ b/wear/src/main/res/layout/action_editplusminus_item.xml
@@ -50,7 +50,7 @@
                 android:text="label"
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 android:textColor="@color/white"
-                android:textSize="25sp" />
+                android:textSize="20sp" />
         </LinearLayout>
         <ImageView
             android:id="@+id/plusbutton"


### PR DESCRIPTION
Unfortunatly I couldn't benefit from the new eCarb dialog on my Polar M600 (screen size 240x240):
![screen](https://user-images.githubusercontent.com/12517693/39650555-da996b76-4fe8-11e8-8cb1-7d163ec41041.png)
So I made changes: Reducing the font size of the labels and shorten the labels `duration [h]` and `start [min]`.
![screen 1](https://user-images.githubusercontent.com/12517693/39650619-29f14cf2-4fe9-11e8-82b5-b26ab29fa352.png)
Another possibility is to reduce the dimension of `+` and `-` buttons.