### PR TITLE
Allow showing 3 hour overview charts

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/OverviewFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/OverviewFragment.java
@@ -314,8 +314,8 @@ public class OverviewFragment extends Fragment implements View.OnClickListener, 
             bgGraph.setOnLongClickListener(new View.OnLongClickListener() {
                 @Override
                 public boolean onLongClick(View v) {
-                    rangeToDisplay += 6;
-                    rangeToDisplay = rangeToDisplay > 24 ? 6 : rangeToDisplay;
+                    rangeToDisplay += 3;
+                    rangeToDisplay = rangeToDisplay > 24 ? 3 : rangeToDisplay;
                     SP.putInt(R.string.key_rangetodisplay, rangeToDisplay);
                     updateGUI("rangeChange");
                     return false;

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/OverviewFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/OverviewFragment.java
@@ -314,7 +314,12 @@ public class OverviewFragment extends Fragment implements View.OnClickListener, 
             bgGraph.setOnLongClickListener(new View.OnLongClickListener() {
                 @Override
                 public boolean onLongClick(View v) {
-                    rangeToDisplay += 3;
+                    if (rangeToDisplay == 3) {
+                        rangeToDisplay += 3;
+                    }
+                    else {
+                        rangeToDisplay += 6;
+                    }
                     rangeToDisplay = rangeToDisplay > 24 ? 3 : rangeToDisplay;
                     SP.putInt(R.string.key_rangetodisplay, rangeToDisplay);
                     updateGUI("rangeChange");

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/graphData/GraphData.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/graphData/GraphData.java
@@ -563,7 +563,7 @@ public class GraphData {
         graph.getViewport().setMaxX(endTime);
         graph.getViewport().setMinX(fromTime);
         graph.getViewport().setXAxisBoundsManual(true);
-        graph.getGridLabelRenderer().setLabelFormatter(new TimeAsXAxisLabelFormatter("HH"));
+        graph.getGridLabelRenderer().setLabelFormatter(new TimeAsXAxisLabelFormatter());
         graph.getGridLabelRenderer().setNumHorizontalLabels(7); // only 7 because of the space
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/graphExtensions/TimeAsXAxisLabelFormatter.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/graphExtensions/TimeAsXAxisLabelFormatter.java
@@ -13,17 +13,29 @@ import java.util.Calendar;
  */
 public class TimeAsXAxisLabelFormatter extends DefaultLabelFormatter {
 
-    protected final String mFormat;
-
-    public TimeAsXAxisLabelFormatter(String format) {
-        mFormat = format;
-    }
+    public TimeAsXAxisLabelFormatter() { }
 
     @Override
     public String formatLabel(double value, boolean isValueX) {
         if (isValueX) {
-            // format as date
-            DateFormat dateFormat = new SimpleDateFormat(mFormat);
+            // If the value falls within a few minutes of an hour, format as HH
+            // If it falls within a few minutes of a half-hour, format as HH:30
+            // Otherwise, format exactly as HH:mm
+            double halfHours = value / (30 * 60 * 1000);
+            double minutes = (halfHours - Math.floor(halfHours)) * 30;
+            String format;
+
+            if (minutes > 5) {
+                format = "HH:mm";
+            }
+            else if ((Math.floor(halfHours) % 2) == 1) {
+                format = "HH:30";
+            }
+            else {
+                format = "HH";
+            }
+            DateFormat dateFormat = new SimpleDateFormat(format);
+
             return dateFormat.format((long) value);
         } else {
             return super.formatLabel(value, isValueX);


### PR DESCRIPTION
X-axis labels on the overview chart can be misleading at the moment as only the hour part is shown, but the line can be on a half-hour. Some intervals can then seem to be 1 hour while the next one looks like 2 hours.

This change keeps the shorter `HH` format where possible and extends out to `HH:30` where it falls on a half hour.

Without this change the chart below is labelled `13 14 16 17 19 20 22`

![screenshot_20180506-194855](https://user-images.githubusercontent.com/31017244/39676673-9f04219e-5166-11e8-83e1-739713c7625a.png)
