### PR TITLE
Make all prediction colors equally dark

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,8 +6,8 @@
     <color name="bolus">#1ea3e5</color>
     <color name="cob">#FFFB8C00</color>
     <color name="carbs">#FFFB8C00</color>
-    <color name="uam">#ffea00</color>
-    <color name="zt">#00ffff</color>
+    <color name="uam">#c9bd60</color>
+    <color name="zt">#00d2d2</color>
     <color name="ratio">#FFFFFF</color>
     <color name="devslopepos">#FFFFFF00</color>
     <color name="devslopeneg">#FFFF00FF</color>


### PR DESCRIPTION
Yellow is confusing since it's used as warning elsewhere and the BG
points are in yellow if above range.

Also personal preference I guess, feel free to close.