### PR TITLE
[Bugfix] On bolus cancel request, cancel all boluses. Partially addresses #646.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/BolusProgressDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/BolusProgressDialog.java
@@ -112,7 +112,7 @@ public class BolusProgressDialog extends DialogFragment implements View.OnClickL
                 stopPressed = true;
                 stopPressedView.setVisibility(View.VISIBLE);
                 stopButton.setVisibility(View.INVISIBLE);
-                ConfigBuilderPlugin.getActivePump().stopBolusDelivering();
+                ConfigBuilderPlugin.getCommandQueue().cancelAllBoluses();
                 break;
         }
     }

--- a/app/src/main/java/info/nightscout/androidaps/queue/CommandQueue.java
+++ b/app/src/main/java/info/nightscout/androidaps/queue/CommandQueue.java
@@ -213,6 +213,12 @@ public class CommandQueue {
         return true;
     }
 
+    public synchronized void cancelAllBoluses() {
+        removeAll(Command.CommandType.BOLUS);
+        removeAll(Command.CommandType.SMB_BOLUS);
+        ConfigBuilderPlugin.getActivePump().stopBolusDelivering();
+    }
+
     // returns true if command is queued
     public boolean tempBasalAbsolute(double absoluteRate, int durationInMinutes, boolean enforceNew, Profile profile, Callback callback) {
         if (!enforceNew && isRunning(Command.CommandType.TEMPBASAL)) {

--- a/app/src/test/java/info/nightscout/androidaps/queue/CommandQueueTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/queue/CommandQueueTest.java
@@ -156,4 +156,24 @@ public class CommandQueueTest extends CommandQueue {
     public boolean isThisProfileSet(Profile profile) {
         return false;
     }
+
+    @Test
+    public void callingCancelAllBolusesClearsQueue() throws Exception {
+        prepareMock(0d, 0);
+
+        // add normal and SMB-bolus to queue
+        Assert.assertEquals(0, size());
+
+        bolus(new DetailedBolusInfo(), null);
+
+        DetailedBolusInfo smb = new DetailedBolusInfo();
+        smb.isSMB = true;
+        bolus(smb, null);
+
+        Assert.assertEquals(2, size());
+
+        // cancelling all boluses clear all boluses from the queue
+        cancelAllBoluses();
+        Assert.assertEquals(0, size());
+    }
 }


### PR DESCRIPTION
Addresses the situation where a request to cancel a user-requested bolus cancels a running SMB, after which the bolus that should have been cancelled is delivered, see 
https://github.com/MilosKozak/AndroidAPS/issues/646#issuecomment-366388323 for discussion.