### PR TITLE
Calculator/wizard: enable COB by default.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
@@ -276,7 +276,7 @@ public class WizardDialog extends DialogFragment implements OnClickListener, Com
 
     private void loadCheckedStates() {
         bgtrendCheckbox.setChecked(SP.getBoolean(MainApp.gs(R.string.key_wizard_include_trend_bg), false));
-        cobCheckbox.setChecked(SP.getBoolean(MainApp.gs(R.string.key_wizard_include_cob), false));
+        cobCheckbox.setChecked(SP.getBoolean(MainApp.gs(R.string.key_wizard_include_cob), true));
     }
 
     @Override


### PR DESCRIPTION
AFAIK this was off switched by default because when COB wasn't
updated, it showed COB 0, suggesting no carbs where active.
Now that COB is always up-to-date, this should be enabled,
since IOB as enabled by default well.

@savek-cc Agreed :-)