### PR TITLE
NSClient as source without advanced filtering

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
@@ -32,6 +32,6 @@ public class SourceNSClientPlugin extends PluginBase implements BgSourceInterfac
 
     @Override
     public boolean advancedFilteringSupported() {
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
People seem to "work around" the restrictions with xDrip by piping the values through NS :/