### PR TITLE
Update prediction colors to match NS.

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,12 +2,16 @@
 <resources>
     <color name="prediction">#ff00ff</color>
     <color name="basal">#00ffff</color>
+
+    <!-- IOB, bolus, COB, carbs, UAM and ZT are synchronised with NS,
+         see lib/plugins/openaps.js, function getForecastPoints in NS -->
     <color name="iob">#1e88e5</color>
     <color name="bolus">#1ea3e5</color>
-    <color name="cob">#FFFB8C00</color>
-    <color name="carbs">#FFFB8C00</color>
-    <color name="uam">#c9bd60</color>
-    <color name="zt">#00d2d2</color>
+    <color name="cob">#FB8C00</color>
+    <color name="carbs">#fb8c00</color>
+    <color name="uam">#ff89ff</color>
+    <color name="zt">#b601b6</color>
+
     <color name="ratio">#FFFFFF</color>
     <color name="devslopepos">#FFFFFF00</color>
     <color name="devslopeneg">#FFFF00FF</color>

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPluginTest.java
@@ -15,6 +15,6 @@ public class SourceNSClientPluginTest {
 
     @Test
     public void advancedFilteringSupported() {
-        Assert.assertEquals(true, SourceNSClientPlugin.getPlugin().advancedFilteringSupported());
+        Assert.assertEquals(false, SourceNSClientPlugin.getPlugin().advancedFilteringSupported());
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1732305/40816078-2ccb1c9c-654b-11e8-9881-3f309ae03d7d.png)


Same as https://github.com/nightscout/cgm-remote-monitor/pull/3607 for AAPS