### PR TITLE
Use a foreground service for the ongoing notification and enforce using it on Oreo and up

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -166,6 +166,8 @@
             android:name=".plugins.Overview.notifications.DismissNotificationService"
             android:exported="false" />
 
+        <service android:name=".plugins.Persistentnotification.DummyService" />
+
         <meta-data
             android:name="io.fabric.ApiKey"
             android:value="59d462666c664c57b29e1d79ea123e01f8057cfa" />

--- a/app/src/main/java/info/nightscout/androidaps/MainApp.java
+++ b/app/src/main/java/info/nightscout/androidaps/MainApp.java
@@ -187,7 +187,7 @@ public class MainApp extends Application {
 
             pluginsList.add(WearPlugin.initPlugin(this));
             pluginsList.add(StatuslinePlugin.initPlugin(this));
-            pluginsList.add(new PersistentNotificationPlugin(this));
+            pluginsList.add(PersistentNotificationPlugin.getPlugin());
             pluginsList.add(NSClientPlugin.getPlugin());
 
             pluginsList.add(sConfigBuilder = ConfigBuilderPlugin.getPlugin());

--- a/app/src/main/java/info/nightscout/androidaps/plugins/ConfigBuilder/ConfigBuilderPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/ConfigBuilder/ConfigBuilderPlugin.java
@@ -113,7 +113,15 @@ public class ConfigBuilderPlugin extends PluginBase {
         pluginList = MainApp.getPluginsList();
         upgradeSettings();
         loadSettings();
+        setAlwaysEnabledPluginsEnabled();
         MainApp.bus().post(new EventAppInitialized());
+    }
+
+    private void setAlwaysEnabledPluginsEnabled() {
+        for (PluginBase plugin : pluginList) {
+            if (plugin.pluginDescription.alwaysEnabled) plugin.setPluginEnabled(plugin.getType(), true);
+        }
+        storeSettings("setAlwaysEnabledPluginsEnabled");
     }
 
     public void storeSettings(String from) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Persistentnotification/DummyService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Persistentnotification/DummyService.java
@@ -1,0 +1,28 @@
+package info.nightscout.androidaps.plugins.Persistentnotification;
+
+import android.app.Notification;
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+public class DummyService extends Service {
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        Notification notification = PersistentNotificationPlugin.getPlugin().updateNotification();
+        if (notification != null) startForeground(PersistentNotificationPlugin.ONGOING_NOTIFICATION_ID, notification);
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        stopForeground(true);
+    }
+}

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Persistentnotification/DummyService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Persistentnotification/DummyService.java
@@ -5,8 +5,10 @@ import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
+/**
+ * Keeps AndroidAPS in foreground state, so it won't be terminated by Android nor get restricted by the background execution limits
+ */
 public class DummyService extends Service {
     @Nullable
     @Override
@@ -17,7 +19,8 @@ public class DummyService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         Notification notification = PersistentNotificationPlugin.getPlugin().updateNotification();
-        if (notification != null) startForeground(PersistentNotificationPlugin.ONGOING_NOTIFICATION_ID, notification);
+        if (notification != null)
+            startForeground(PersistentNotificationPlugin.ONGOING_NOTIFICATION_ID, notification);
         return START_STICKY;
     }
 


### PR DESCRIPTION
Pretty similiar to #870, makes sure that AndroidAPS won't be terminated by the system.