### PR TITLE
Insight bolus history merge

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/Treatment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/Treatment.java
@@ -40,10 +40,10 @@ public class Treatment implements DataPointWithLabelInterface {
     public boolean isValid = true;
 
     @DatabaseField(index = true)
-    public long pumpId = 0;
+    public volatile long pumpId = 0;
 
     @DatabaseField
-    public int source = Source.NONE;
+    public volatile int source = Source.NONE;
     @DatabaseField
     public String _id;
 
@@ -101,6 +101,7 @@ public class Treatment implements DataPointWithLabelInterface {
                 ", insulin= " + insulin +
                 ", carbs= " + carbs +
                 ", mealBolus= " + mealBolus +
+                ", source= " + Source.getString(source) +
                 "}";
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/TreatmentService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/TreatmentService.java
@@ -418,6 +418,22 @@ public class TreatmentService extends OrmLiteBaseService<DatabaseHelper> {
         return new ArrayList<>();
     }
 
+
+    public Treatment getBolusFromHistoryNearestToTime(long timestamp) {
+        final List<Treatment> treatments = TreatmentsPlugin.getPlugin().getTreatmentsFromHistory();
+        long closest_difference = -1;
+        Treatment result = null;
+        for (Treatment record : treatments) {
+            if (!record.isValid) continue;
+            if (record.insulin <= 0) continue;
+            if ((result == null) || (Math.abs(record.date - timestamp) < closest_difference)) {
+                closest_difference = Math.abs(record.date - timestamp);
+                result = record;
+            }
+        }
+        return result;
+    }
+
     @Nullable
     @Override
     public IBinder onBind(Intent intent) {


### PR DESCRIPTION
There is an issue with the way the History is processed from the Insight that very often the log ends up with one entry as `Source.User` when the bolus is created another duplicate entry with `Source.Pump` when the history is read.

This causes a problem that the IoB is calculated as double what it should be causing the algorithm to not have an accurate model.

This patch works by looking for a matching `Source.User` record in the local history when processing data incoming from the pump and if one is found which has the same amount of insulin and is within 30 seconds of the existing record then instead of creating a new record the record type is changed to `Source.Pump` and the pump id field also updated.

This approach was taken because it is easier than deleting the existing record and seems to make sense as the record represents the same bolus except that it is now confirmed from the pump.

It will now correctly calculate the IoB whether or not history could not be retrieved immediately from the pump after the bolus was delivered.

I am assuming that whether or not nightscout is updated with the updated record will make no difference because the only data which changes in the record is the source and pump id fields.

This has been locally tested for a day or so and the problem appears to be resolved and the history sync has been reliable. 

Comments welcomed!