### PR TITLE
Don't loop for values from non-active BG sources

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/Services/Intents.java
+++ b/app/src/main/java/info/nightscout/androidaps/Services/Intents.java
@@ -38,6 +38,7 @@ public interface Intents {
     String EXTRA_TIMESTAMP = "com.eveningoutpost.dexdrip.Extras.Time";
     String EXTRA_RAW = "com.eveningoutpost.dexdrip.Extras.Raw";
     String XDRIP_DATA_SOURCE_DESCRIPTION = "com.eveningoutpost.dexdrip.Extras.SourceDesc";
+    String EXTRA_NOISE = "com.eveningoutpost.dexdrip.Extras.Noise";
 
 
     String ACTION_NEW_BG_ESTIMATE_NO_DATA = "com.eveningoutpost.dexdrip.BgEstimateNoData";

--- a/app/src/main/java/info/nightscout/androidaps/Services/Intents.java
+++ b/app/src/main/java/info/nightscout/androidaps/Services/Intents.java
@@ -38,7 +38,6 @@ public interface Intents {
     String EXTRA_TIMESTAMP = "com.eveningoutpost.dexdrip.Extras.Time";
     String EXTRA_RAW = "com.eveningoutpost.dexdrip.Extras.Raw";
     String XDRIP_DATA_SOURCE_DESCRIPTION = "com.eveningoutpost.dexdrip.Extras.SourceDesc";
-    String EXTRA_NOISE = "com.eveningoutpost.dexdrip.Extras.Noise";
 
 
     String ACTION_NEW_BG_ESTIMATE_NO_DATA = "com.eveningoutpost.dexdrip.BgEstimateNoData";

--- a/app/src/main/java/info/nightscout/androidaps/data/ConstraintChecker.java
+++ b/app/src/main/java/info/nightscout/androidaps/data/ConstraintChecker.java
@@ -42,10 +42,6 @@ public class ConstraintChecker implements ConstraintsInterface {
         return isSMBModeEnabled(new Constraint<>(true));
     }
 
-    public Constraint<Boolean> isAdvancedFilteringEnabled() {
-        return isAdvancedFilteringEnabled(new Constraint<>(true));
-    }
-
     public Constraint<Double> getMaxBasalAllowed(Profile profile) {
         return applyBasalConstraints(new Constraint<>(Constants.REALLYHIGHBASALRATE), profile);
     }
@@ -69,7 +65,7 @@ public class ConstraintChecker implements ConstraintsInterface {
     @Override
     public Constraint<Boolean> isLoopInvocationAllowed(Constraint<Boolean> value) {
 
-        ArrayList<PluginBase> constraintsPlugins = mainApp.getSpecificPluginsListByInterface(ConstraintsInterface.class);
+        ArrayList<PluginBase> constraintsPlugins = MainApp.getSpecificPluginsListByInterface(ConstraintsInterface.class);
         for (PluginBase p : constraintsPlugins) {
             ConstraintsInterface constraint = (ConstraintsInterface) p;
             if (!p.isEnabled(PluginType.CONSTRAINTS)) continue;
@@ -81,7 +77,7 @@ public class ConstraintChecker implements ConstraintsInterface {
     @Override
     public Constraint<Boolean> isClosedLoopAllowed(Constraint<Boolean> value) {
 
-        ArrayList<PluginBase> constraintsPlugins = mainApp.getSpecificPluginsListByInterface(ConstraintsInterface.class);
+        ArrayList<PluginBase> constraintsPlugins = MainApp.getSpecificPluginsListByInterface(ConstraintsInterface.class);
         for (PluginBase p : constraintsPlugins) {
             ConstraintsInterface constraint = (ConstraintsInterface) p;
             if (!p.isEnabled(PluginType.CONSTRAINTS)) continue;
@@ -122,17 +118,6 @@ public class ConstraintChecker implements ConstraintsInterface {
             ConstraintsInterface constraint = (ConstraintsInterface) p;
             if (!p.isEnabled(PluginType.CONSTRAINTS)) continue;
             constraint.isSMBModeEnabled(value);
-        }
-        return value;
-    }
-
-    @Override
-    public Constraint<Boolean> isAdvancedFilteringEnabled(Constraint<Boolean> value) {
-        ArrayList<PluginBase> constraintsPlugins = mainApp.getSpecificPluginsListByInterface(ConstraintsInterface.class);
-        for (PluginBase p : constraintsPlugins) {
-            ConstraintsInterface constraint = (ConstraintsInterface) p;
-            if (!p.isEnabled(PluginType.CONSTRAINTS)) continue;
-            constraint.isAdvancedFilteringEnabled(value);
         }
         return value;
     }

--- a/app/src/main/java/info/nightscout/androidaps/db/BgReading.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/BgReading.java
@@ -37,8 +37,6 @@ public class BgReading implements DataPointWithLabelInterface {
     @DatabaseField
     public double raw;
     @DatabaseField
-    public double noise = -999; // xDrip sends -999 to indicate lack of a noise reading (due to missed readings or calibration)
-    @DatabaseField
     public boolean isFiltered;
     @DatabaseField
     public String sourcePlugin;
@@ -154,7 +152,6 @@ public class BgReading implements DataPointWithLabelInterface {
         raw = other.raw;
         direction = other.direction;
         _id = other._id;
-        noise = other.noise;
         sourcePlugin = other.sourcePlugin;
         isFiltered = other.isFiltered;
     }

--- a/app/src/main/java/info/nightscout/androidaps/db/BgReading.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/BgReading.java
@@ -38,6 +38,10 @@ public class BgReading implements DataPointWithLabelInterface {
     public String direction;
     @DatabaseField
     public double raw;
+    @DatabaseField
+    public boolean filtered;
+    @DatabaseField
+    public String sourcePlugin;
 
     @DatabaseField
     public int source = Source.NONE;
@@ -120,17 +124,9 @@ public class BgReading implements DataPointWithLabelInterface {
                 ", value=" + value +
                 ", direction=" + direction +
                 ", raw=" + raw +
+                ", filtered=" + filtered +
+                ", sourcePlugin=" + sourcePlugin +
                 '}';
-    }
-
-    public boolean isDataChanging(BgReading other) {
-        if (date != other.date) {
-            log.error("Comparing different");
-            return false;
-        }
-        if (value != other.value)
-            return true;
-        return false;
     }
 
     public boolean isEqual(BgReading other) {
@@ -158,6 +154,8 @@ public class BgReading implements DataPointWithLabelInterface {
         raw = other.raw;
         direction = other.direction;
         _id = other._id;
+        sourcePlugin = other.sourcePlugin;
+        filtered = other.filtered;
     }
 
     // ------------------ DataPointWithLabelInterface ------------------

--- a/app/src/main/java/info/nightscout/androidaps/db/BgReading.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/BgReading.java
@@ -39,7 +39,7 @@ public class BgReading implements DataPointWithLabelInterface {
     @DatabaseField
     public double noise = -999; // xDrip sends -999 to indicate lack of a noise reading (due to missed readings or calibration)
     @DatabaseField
-    public boolean filtered;
+    public boolean isFiltered;
     @DatabaseField
     public String sourcePlugin;
 
@@ -124,7 +124,7 @@ public class BgReading implements DataPointWithLabelInterface {
                 ", value=" + value +
                 ", direction=" + direction +
                 ", raw=" + raw +
-                ", filtered=" + filtered +
+                ", filtered=" + isFiltered +
                 ", sourcePlugin=" + sourcePlugin +
                 '}';
     }
@@ -156,7 +156,7 @@ public class BgReading implements DataPointWithLabelInterface {
         _id = other._id;
         noise = other.noise;
         sourcePlugin = other.sourcePlugin;
-        filtered = other.filtered;
+        isFiltered = other.isFiltered;
     }
 
     // ------------------ DataPointWithLabelInterface ------------------

--- a/app/src/main/java/info/nightscout/androidaps/db/BgReading.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/BgReading.java
@@ -1,7 +1,5 @@
 package info.nightscout.androidaps.db;
 
-import android.content.res.Resources;
-
 import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.table.DatabaseTable;
 
@@ -38,6 +36,8 @@ public class BgReading implements DataPointWithLabelInterface {
     public String direction;
     @DatabaseField
     public double raw;
+    @DatabaseField
+    public double noise = -999; // xDrip sends -999 to indicate lack of a noise reading (due to missed readings or calibration)
     @DatabaseField
     public boolean filtered;
     @DatabaseField
@@ -154,6 +154,7 @@ public class BgReading implements DataPointWithLabelInterface {
         raw = other.raw;
         direction = other.direction;
         _id = other._id;
+        noise = other.noise;
         sourcePlugin = other.sourcePlugin;
         filtered = other.filtered;
     }

--- a/app/src/main/java/info/nightscout/androidaps/db/BgReading.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/BgReading.java
@@ -152,8 +152,6 @@ public class BgReading implements DataPointWithLabelInterface {
         raw = other.raw;
         direction = other.direction;
         _id = other._id;
-        sourcePlugin = other.sourcePlugin;
-        isFiltered = other.isFiltered;
     }
 
     // ------------------ DataPointWithLabelInterface ------------------

--- a/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
@@ -123,8 +123,6 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
                     "isFiltered", "integer");
             createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
                     "sourcePlugin", "text");
-            createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
-                    "noise", "real");
 
         } catch (SQLException e) {
             log.error("Can't create database", e);

--- a/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
@@ -117,9 +117,24 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
             TableUtils.createTableIfNotExists(connectionSource, CareportalEvent.class);
             TableUtils.createTableIfNotExists(connectionSource, ProfileSwitch.class);
             TableUtils.createTableIfNotExists(connectionSource, TDD.class);
+
+            // soft migration without changing DB version
+            createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
+                    "filtered", "integer");
+            createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
+                    "sourcePlugin", "integer");
+
         } catch (SQLException e) {
             log.error("Can't create database", e);
             throw new RuntimeException(e);
+        }
+    }
+
+    private void createRowIfNotExists(Dao dao, String table, String name, String type) {
+        try {
+            dao.executeRaw("ALTER TABLE `" + table + "` ADD CoLUMN `" + name + " " + type);
+        } catch (SQLException e) {
+            // row already exists
         }
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
@@ -122,7 +122,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
             createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
                     "filtered", "integer");
             createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
-                    "sourcePlugin", "integer");
+                    "sourcePlugin", "text");
 
         } catch (SQLException e) {
             log.error("Can't create database", e);
@@ -132,7 +132,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
 
     private void createRowIfNotExists(Dao dao, String table, String name, String type) {
         try {
-            dao.executeRaw("ALTER TABLE `" + table + "` ADD CoLUMN `" + name + " " + type);
+            dao.executeRaw("ALTER TABLE `" + table + "` ADD COLUMN `" + name + " " + type);
         } catch (SQLException e) {
             // row already exists
         }

--- a/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
@@ -132,7 +132,8 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
 
     private void createRowIfNotExists(Dao dao, String table, String name, String type) {
         try {
-            dao.executeRaw("ALTER TABLE `" + table + "` ADD COLUMN `" + name + " " + type);
+            final String statement = "ALTER TABLE `" + table + "` ADD COLUMN `" + name + "` " + type;
+            dao.executeRaw(statement);
         } catch (SQLException e) {
             // row already exists
         }

--- a/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
@@ -123,6 +123,8 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
                     "filtered", "integer");
             createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
                     "sourcePlugin", "text");
+            createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
+                    "noise", "real");
 
         } catch (SQLException e) {
             log.error("Can't create database", e);

--- a/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
@@ -120,7 +120,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
 
             // soft migration without changing DB version
             createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
-                    "filtered", "integer");
+                    "isFiltered", "integer");
             createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
                     "sourcePlugin", "text");
             createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,

--- a/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import info.nightscout.androidaps.Config;
-import info.nightscout.androidaps.Constants;
 import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.data.Profile;
 import info.nightscout.androidaps.data.ProfileStore;
@@ -119,9 +118,9 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
             TableUtils.createTableIfNotExists(connectionSource, TDD.class);
 
             // soft migration without changing DB version
-            createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
+            createColumnIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
                     "isFiltered", "integer");
-            createRowIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
+            createColumnIfNotExists(getDaoBgReadings(), DatabaseHelper.DATABASE_BGREADINGS,
                     "sourcePlugin", "text");
 
         } catch (SQLException e) {
@@ -130,7 +129,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
         }
     }
 
-    private void createRowIfNotExists(Dao dao, String table, String name, String type) {
+    private void createColumnIfNotExists(Dao dao, String table, String name, String type) {
         try {
             final String statement = "ALTER TABLE `" + table + "` ADD COLUMN `" + name + "` " + type;
             dao.executeRaw(statement);

--- a/app/src/main/java/info/nightscout/androidaps/interfaces/BgSourceInterface.java
+++ b/app/src/main/java/info/nightscout/androidaps/interfaces/BgSourceInterface.java
@@ -3,6 +3,4 @@ package info.nightscout.androidaps.interfaces;
 /**
  * Created by mike on 20.06.2016.
  */
-public interface BgSourceInterface {
-    boolean advancedFilteringSupported();
-}
+public interface BgSourceInterface {}

--- a/app/src/main/java/info/nightscout/androidaps/interfaces/BgSourceInterface.java
+++ b/app/src/main/java/info/nightscout/androidaps/interfaces/BgSourceInterface.java
@@ -2,9 +2,13 @@ package info.nightscout.androidaps.interfaces;
 
 import android.os.Bundle;
 
+import java.util.List;
+
+import info.nightscout.androidaps.db.BgReading;
+
 /**
  * Created by mike on 20.06.2016.
  */
 public interface BgSourceInterface {
-    void processNewData(Bundle bundle);
+    List<BgReading> processNewData(Bundle bundle);
 }

--- a/app/src/main/java/info/nightscout/androidaps/interfaces/BgSourceInterface.java
+++ b/app/src/main/java/info/nightscout/androidaps/interfaces/BgSourceInterface.java
@@ -1,6 +1,10 @@
 package info.nightscout.androidaps.interfaces;
 
+import android.os.Bundle;
+
 /**
  * Created by mike on 20.06.2016.
  */
-public interface BgSourceInterface {}
+public interface BgSourceInterface {
+    void processNewData(Bundle bundle);
+}

--- a/app/src/main/java/info/nightscout/androidaps/interfaces/ConstraintsInterface.java
+++ b/app/src/main/java/info/nightscout/androidaps/interfaces/ConstraintsInterface.java
@@ -27,10 +27,6 @@ public interface ConstraintsInterface {
         return value;
     }
 
-    default Constraint<Boolean> isAdvancedFilteringEnabled(Constraint<Boolean> value) {
-        return value;
-    }
-
     default Constraint<Double> applyBasalConstraints(Constraint<Double> absoluteRate, Profile profile) {
         return absoluteRate;
     }

--- a/app/src/main/java/info/nightscout/androidaps/interfaces/PluginDescription.java
+++ b/app/src/main/java/info/nightscout/androidaps/interfaces/PluginDescription.java
@@ -1,7 +1,5 @@
 package info.nightscout.androidaps.interfaces;
 
-import info.nightscout.androidaps.MainApp;
-
 public class PluginDescription {
     PluginType mainType = PluginType.GENERAL;
     String fragmentClass = null;
@@ -88,9 +86,5 @@ public class PluginDescription {
 
     public PluginType getType() {
         return mainType;
-    }
-
-    public String getUserfriendlyName() {
-        return MainApp.gs(pluginName);
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/interfaces/PluginDescription.java
+++ b/app/src/main/java/info/nightscout/androidaps/interfaces/PluginDescription.java
@@ -1,5 +1,7 @@
 package info.nightscout.androidaps.interfaces;
 
+import info.nightscout.androidaps.MainApp;
+
 public class PluginDescription {
     PluginType mainType = PluginType.GENERAL;
     String fragmentClass = null;
@@ -86,5 +88,9 @@ public class PluginDescription {
 
     public PluginType getType() {
         return mainType;
+    }
+
+    public String getUserfriendlyName() {
+        return MainApp.gs(pluginName);
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/ConfigBuilder/ConfigBuilderPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/ConfigBuilder/ConfigBuilderPlugin.java
@@ -65,12 +65,11 @@ public class ConfigBuilderPlugin extends PluginBase {
         return configBuilderPlugin;
     }
 
-    private BgSourceInterface activeBgSource;
+    private static BgSourceInterface activeBgSource;
     private static PumpInterface activePump;
     private static ProfileInterface activeProfile;
     private static TreatmentsInterface activeTreatments;
     private static APSInterface activeAPS;
-    private static LoopPlugin activeLoop;
     private static InsulinInterface activeInsulin;
     private static SensitivityInterface activeSensitivity;
 
@@ -249,7 +248,7 @@ public class ConfigBuilderPlugin extends PluginBase {
         return commandQueue;
     }
 
-    public BgSourceInterface getActiveBgSource() {
+    public static BgSourceInterface getActiveBgSource() {
         return activeBgSource;
     }
 
@@ -328,9 +327,6 @@ public class ConfigBuilderPlugin extends PluginBase {
             VirtualPumpPlugin.getPlugin().setPluginEnabled(PluginType.PUMP, true);
         }
         this.setFragmentVisiblities(((PluginBase) activePump).getName(), pluginsInCategory, PluginType.PUMP);
-
-        // PluginType.LOOP
-        activeLoop = this.determineActivePlugin(PluginType.LOOP);
 
         // PluginType.TREATMENT
         activeTreatments = this.determineActivePlugin(PluginType.TREATMENT);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/ConstraintsSafety/SafetyPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/ConstraintsSafety/SafetyPlugin.java
@@ -93,17 +93,6 @@ public class SafetyPlugin extends PluginBase implements ConstraintsInterface {
     }
 
     @Override
-    public Constraint<Boolean> isAdvancedFilteringEnabled(Constraint<Boolean> value) {
-        BgSourceInterface bgSource = MainApp.getConfigBuilder().getActiveBgSource();
-
-        if (bgSource != null) {
-            if (!bgSource.advancedFilteringSupported())
-                value.set(false, MainApp.gs(R.string.smbalwaysdisabled), this);
-        }
-        return value;
-    }
-
-    @Override
     public Constraint<Double> applyBasalConstraints(Constraint<Double> absoluteRate, Profile profile) {
 
         absoluteRate.setIfGreater(0d, String.format(MainApp.gs(R.string.limitingbasalratio), 0d, MainApp.gs(R.string.itmustbepositivevalue)), this);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Date;
+import java.util.Objects;
 
 import info.nightscout.androidaps.Config;
 import info.nightscout.androidaps.Constants;
@@ -32,7 +33,6 @@ import info.nightscout.androidaps.db.BgReading;
 import info.nightscout.androidaps.db.DatabaseHelper;
 import info.nightscout.androidaps.events.Event;
 import info.nightscout.androidaps.events.EventNewBG;
-import info.nightscout.androidaps.events.EventTreatmentChange;
 import info.nightscout.androidaps.interfaces.APSInterface;
 import info.nightscout.androidaps.interfaces.Constraint;
 import info.nightscout.androidaps.interfaces.PluginBase;
@@ -57,11 +57,9 @@ import info.nightscout.utils.SP;
 public class LoopPlugin extends PluginBase {
     private static Logger log = LoggerFactory.getLogger(LoopPlugin.class);
 
-    public static final String CHANNEL_ID = "AndroidAPS-Openloop";
-
-    long lastBgTriggeredRun = 0;
-
-    protected static LoopPlugin loopPlugin;
+    private static final String CHANNEL_ID = "AndroidAPS-Openloop";
+    private long lastBgTriggeredRun = 0;
+    private static LoopPlugin loopPlugin;
 
     @NonNull
     public static LoopPlugin getPlugin() {
@@ -157,13 +155,18 @@ public class LoopPlugin extends PluginBase {
             // already looped with that value
             return;
         }
+        PluginBase bgSource = (PluginBase) ConfigBuilderPlugin.getActiveBgSource();
+        if (bgSource == null) {
+            // no BG source active
+            return;
+        }
+        if (!Objects.equals(bgReading.sourcePlugin, bgSource.pluginDescription.getUserfriendlyName())) {
+            // reading not from active BG source (likely coming in from NS)
+            return;
+        }
 
         lastBgTriggeredRun = bgReading.date;
         invoke("AutosenseCalculation for " + bgReading, true);
-    }
-
-    public long suspendedTo() {
-        return loopSuspendedTill;
     }
 
     public void suspendTo(long endTime) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
@@ -160,7 +160,7 @@ public class LoopPlugin extends PluginBase {
             // no BG source active
             return;
         }
-        if (!Objects.equals(bgReading.sourcePlugin, bgSource.pluginDescription.getUserfriendlyName())) {
+        if (!Objects.equals(bgReading.sourcePlugin, bgSource.getName())) {
             // reading not from active BG source (likely coming in from NS)
             return;
         }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/OpenAPSSMBPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/OpenAPSSMBPlugin.java
@@ -192,8 +192,8 @@ public class OpenAPSSMBPlugin extends PluginBase implements APSInterface {
         MainApp.getConstraintChecker().isSMBModeEnabled(smbAllowed);
         inputConstraints.copyReasons(smbAllowed);
 
-        Constraint<Boolean> bgFiltered = new Constraint<>(bgReading.filtered);
-        if (!bgReading.filtered) {
+        Constraint<Boolean> bgFiltered = new Constraint<>(bgReading.isFiltered);
+        if (!bgReading.isFiltered) {
             bgFiltered.set(false, MainApp.gs(R.string.smbalwaysdisabled), this);
         }
         inputConstraints.copyReasons(bgFiltered);
@@ -207,7 +207,7 @@ public class OpenAPSSMBPlugin extends PluginBase implements APSInterface {
                     lastAutosensResult.ratio, //autosensDataRatio
                     isTempTarget,
                     smbAllowed.value(),
-                    bgReading.filtered
+                    bgReading.isFiltered
             );
         } catch (JSONException e) {
             log.error(e.getMessage());

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/OpenAPSSMBPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/OpenAPSSMBPlugin.java
@@ -14,6 +14,8 @@ import info.nightscout.androidaps.data.GlucoseStatus;
 import info.nightscout.androidaps.data.IobTotal;
 import info.nightscout.androidaps.data.MealData;
 import info.nightscout.androidaps.data.Profile;
+import info.nightscout.androidaps.db.BgReading;
+import info.nightscout.androidaps.db.DatabaseHelper;
 import info.nightscout.androidaps.db.TempTarget;
 import info.nightscout.androidaps.db.TemporaryBasal;
 import info.nightscout.androidaps.interfaces.APSInterface;
@@ -104,6 +106,7 @@ public class OpenAPSSMBPlugin extends PluginBase implements APSInterface {
         }
 
         GlucoseStatus glucoseStatus = GlucoseStatus.getGlucoseStatusData();
+        BgReading bgReading = DatabaseHelper.actualBg();
         Profile profile = MainApp.getConfigBuilder().getProfile();
         PumpInterface pump = ConfigBuilderPlugin.getActivePump();
 
@@ -121,7 +124,7 @@ public class OpenAPSSMBPlugin extends PluginBase implements APSInterface {
             return;
         }
 
-        if (glucoseStatus == null) {
+        if (glucoseStatus == null || bgReading == null) {
             MainApp.bus().post(new EventOpenAPSUpdateResultGui(MainApp.gs(R.string.openapsma_noglucosedata)));
             if (Config.logAPSResult)
                 log.debug(MainApp.gs(R.string.openapsma_noglucosedata));
@@ -189,10 +192,6 @@ public class OpenAPSSMBPlugin extends PluginBase implements APSInterface {
         MainApp.getConstraintChecker().isSMBModeEnabled(smbAllowed);
         inputConstraints.copyReasons(smbAllowed);
 
-        Constraint<Boolean> advancedFiltering = new Constraint<>(!tempBasalFallback);
-        MainApp.getConstraintChecker().isAdvancedFilteringEnabled(advancedFiltering);
-        inputConstraints.copyReasons(advancedFiltering);
-
         Profiler.log(log, "detectSensitivityandCarbAbsorption()", startPart);
         Profiler.log(log, "SMB data gathering", start);
 
@@ -202,7 +201,7 @@ public class OpenAPSSMBPlugin extends PluginBase implements APSInterface {
                     lastAutosensResult.ratio, //autosensDataRatio
                     isTempTarget,
                     smbAllowed.value(),
-                    advancedFiltering.value()
+                    bgReading.filtered
             );
         } catch (JSONException e) {
             log.error(e.getMessage());

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/OpenAPSSMBPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/OpenAPSSMBPlugin.java
@@ -192,6 +192,12 @@ public class OpenAPSSMBPlugin extends PluginBase implements APSInterface {
         MainApp.getConstraintChecker().isSMBModeEnabled(smbAllowed);
         inputConstraints.copyReasons(smbAllowed);
 
+        Constraint<Boolean> bgFiltered = new Constraint<>(bgReading.filtered);
+        if (!bgReading.filtered) {
+            bgFiltered.set(false, MainApp.gs(R.string.smbalwaysdisabled), this);
+        }
+        inputConstraints.copyReasons(bgFiltered);
+
         Profiler.log(log, "detectSensitivityandCarbAbsorption()", startPart);
         Profiler.log(log, "SMB data gathering", start);
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceDexcomG5Plugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceDexcomG5Plugin.java
@@ -33,8 +33,4 @@ public class SourceDexcomG5Plugin extends PluginBase implements BgSourceInterfac
         );
     }
 
-    @Override
-    public boolean advancedFilteringSupported() {
-        return true;
-    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceDexcomG5Plugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceDexcomG5Plugin.java
@@ -71,7 +71,7 @@ public class SourceDexcomG5Plugin extends PluginBase implements BgSourceInterfac
                 bgReading.date = json.getLong("m_time") * 1000L;
                 bgReading.raw = 0;
                 bgReading.filtered = true;
-                bgReading.sourcePlugin = SourceDexcomG5Plugin.getPlugin().getName();
+                bgReading.sourcePlugin = getName();
                 boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());
                 if (isNew) {
                     bgReadings.add(bgReading);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceDexcomG5Plugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceDexcomG5Plugin.java
@@ -1,17 +1,30 @@
 package info.nightscout.androidaps.plugins.Source;
 
+import android.os.Bundle;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import info.nightscout.androidaps.Config;
+import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.R;
+import info.nightscout.androidaps.db.BgReading;
 import info.nightscout.androidaps.interfaces.BgSourceInterface;
 import info.nightscout.androidaps.interfaces.PluginBase;
 import info.nightscout.androidaps.interfaces.PluginDescription;
 import info.nightscout.androidaps.interfaces.PluginType;
+import info.nightscout.utils.NSUpload;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 28.11.2017.
  */
 
 public class SourceDexcomG5Plugin extends PluginBase implements BgSourceInterface {
+    private static final Logger log = LoggerFactory.getLogger(SourceDexcomG5Plugin.class);
 
     private static SourceDexcomG5Plugin plugin = null;
 
@@ -33,4 +46,35 @@ public class SourceDexcomG5Plugin extends PluginBase implements BgSourceInterfac
         );
     }
 
+    @Override
+    public void processNewData(Bundle bundle) {
+        BgReading bgReading = new BgReading();
+
+        String data = bundle.getString("data");
+        // onHandleIntent Bundle{ data => [{"m_time":1511939180,"m_trend":"NotComputable","m_value":335}]; android.support.content.wakelockid => 95; }Bundle
+        log.debug("Received Dexcom Data", data);
+
+        try {
+            JSONArray jsonArray = new JSONArray(data);
+            log.debug("Received Dexcom Data size:" + jsonArray.length());
+            for (int i = 0; i < jsonArray.length(); i++) {
+                JSONObject json = jsonArray.getJSONObject(i);
+                bgReading.value = json.getInt("m_value");
+                bgReading.direction = json.getString("m_trend");
+                bgReading.date = json.getLong("m_time") * 1000L;
+                bgReading.raw = 0;
+                bgReading.filtered = true;
+                bgReading.sourcePlugin = SourceDexcomG5Plugin.getPlugin().getName();
+                boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, "DexcomG5");
+                if (isNew && SP.getBoolean(R.string.key_dexcomg5_nsupload, false)) {
+                    NSUpload.uploadBg(bgReading);
+                }
+                if (isNew && SP.getBoolean(R.string.key_dexcomg5_xdripupload, false)) {
+                    NSUpload.sendToXdrip(bgReading);
+                }
+            }
+        } catch (JSONException e) {
+            log.error("Unhandled exception", e);
+        }
+    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceDexcomG5Plugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceDexcomG5Plugin.java
@@ -2,8 +2,6 @@ package info.nightscout.androidaps.plugins.Source;
 
 import android.os.Bundle;
 
-import com.google.common.collect.Lists;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -11,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import info.nightscout.androidaps.Config;
@@ -70,7 +67,7 @@ public class SourceDexcomG5Plugin extends PluginBase implements BgSourceInterfac
                 bgReading.direction = json.getString("m_trend");
                 bgReading.date = json.getLong("m_time") * 1000L;
                 bgReading.raw = 0;
-                bgReading.filtered = true;
+                bgReading.isFiltered = true;
                 bgReading.sourcePlugin = getName();
                 boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());
                 if (isNew) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPlugin.java
@@ -46,7 +46,7 @@ public class SourceGlimpPlugin extends PluginBase implements BgSourceInterface {
         bgReading.date = bundle.getLong("myTimestamp");
         bgReading.raw = 0;
         bgReading.filtered = false;
-        bgReading.sourcePlugin = SourceGlimpPlugin.getPlugin().getName();
+        bgReading.sourcePlugin = getName();
 
         boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());
         return isNew ? Lists.newArrayList(bgReading) : Collections.emptyList();

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPlugin.java
@@ -45,7 +45,7 @@ public class SourceGlimpPlugin extends PluginBase implements BgSourceInterface {
         bgReading.direction = bundle.getString("myTrend");
         bgReading.date = bundle.getLong("myTimestamp");
         bgReading.raw = 0;
-        bgReading.filtered = false;
+        bgReading.isFiltered = false;
         bgReading.sourcePlugin = getName();
 
         boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPlugin.java
@@ -2,6 +2,11 @@ package info.nightscout.androidaps.plugins.Source;
 
 import android.os.Bundle;
 
+import com.google.common.collect.Lists;
+
+import java.util.Collections;
+import java.util.List;
+
 import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.R;
 import info.nightscout.androidaps.db.BgReading;
@@ -33,7 +38,7 @@ public class SourceGlimpPlugin extends PluginBase implements BgSourceInterface {
     }
 
     @Override
-    public void processNewData(Bundle bundle) {
+    public List<BgReading> processNewData(Bundle bundle) {
         BgReading bgReading = new BgReading();
 
         bgReading.value = bundle.getDouble("mySGV");
@@ -43,6 +48,7 @@ public class SourceGlimpPlugin extends PluginBase implements BgSourceInterface {
         bgReading.filtered = false;
         bgReading.sourcePlugin = SourceGlimpPlugin.getPlugin().getName();
 
-        MainApp.getDbHelper().createIfNotExists(bgReading, getName());
+        boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());
+        return isNew ? Lists.newArrayList(bgReading) : Collections.emptyList();
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPlugin.java
@@ -28,8 +28,4 @@ public class SourceGlimpPlugin extends PluginBase implements BgSourceInterface {
         );
     }
 
-    @Override
-    public boolean advancedFilteringSupported() {
-        return false;
-    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPlugin.java
@@ -1,6 +1,10 @@
 package info.nightscout.androidaps.plugins.Source;
 
+import android.os.Bundle;
+
+import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.R;
+import info.nightscout.androidaps.db.BgReading;
 import info.nightscout.androidaps.interfaces.BgSourceInterface;
 import info.nightscout.androidaps.interfaces.PluginBase;
 import info.nightscout.androidaps.interfaces.PluginDescription;
@@ -28,4 +32,17 @@ public class SourceGlimpPlugin extends PluginBase implements BgSourceInterface {
         );
     }
 
+    @Override
+    public void processNewData(Bundle bundle) {
+        BgReading bgReading = new BgReading();
+
+        bgReading.value = bundle.getDouble("mySGV");
+        bgReading.direction = bundle.getString("myTrend");
+        bgReading.date = bundle.getLong("myTimestamp");
+        bgReading.raw = 0;
+        bgReading.filtered = false;
+        bgReading.sourcePlugin = SourceGlimpPlugin.getPlugin().getName();
+
+        MainApp.getDbHelper().createIfNotExists(bgReading, getName());
+    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceMM640gPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceMM640gPlugin.java
@@ -64,7 +64,7 @@ public class SourceMM640gPlugin extends PluginBase implements BgSourceInterface 
                                 bgReading.direction = json_object.getString("direction");
                                 bgReading.date = json_object.getLong("date");
                                 bgReading.raw = json_object.getDouble("sgv");
-                                bgReading.filtered = true;
+                                bgReading.isFiltered = true;
                                 bgReading.sourcePlugin = getName();
 
                                 boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceMM640gPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceMM640gPlugin.java
@@ -27,8 +27,4 @@ public class SourceMM640gPlugin extends PluginBase implements BgSourceInterface 
         );
     }
 
-    @Override
-    public boolean advancedFilteringSupported() {
-        return false;
-    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceMM640gPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceMM640gPlugin.java
@@ -65,7 +65,7 @@ public class SourceMM640gPlugin extends PluginBase implements BgSourceInterface 
                                 bgReading.date = json_object.getLong("date");
                                 bgReading.raw = json_object.getDouble("sgv");
                                 bgReading.filtered = true;
-                                bgReading.sourcePlugin = SourceMM640gPlugin.getPlugin().getName();
+                                bgReading.sourcePlugin = getName();
 
                                 boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());
                                 if (isNew) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceMM640gPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceMM640gPlugin.java
@@ -8,6 +8,10 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.R;
 import info.nightscout.androidaps.db.BgReading;
@@ -40,11 +44,10 @@ public class SourceMM640gPlugin extends PluginBase implements BgSourceInterface 
     }
 
     @Override
-    public void processNewData(Bundle bundle) {
-        final String collection = bundle.getString("collection");
-        if (collection == null) return;
+    public List<BgReading> processNewData(Bundle bundle) {
+        List<BgReading> bgReadings = new ArrayList<>();
 
-        if (collection.equals("entries")) {
+        if (Objects.equals(bundle.getString("collection"), "entries")) {
             final String data = bundle.getString("data");
 
             if ((data != null) && (data.length() > 0)) {
@@ -64,7 +67,10 @@ public class SourceMM640gPlugin extends PluginBase implements BgSourceInterface 
                                 bgReading.filtered = true;
                                 bgReading.sourcePlugin = SourceMM640gPlugin.getPlugin().getName();
 
-                                MainApp.getDbHelper().createIfNotExists(bgReading, "MM640g");
+                                boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());
+                                if (isNew) {
+                                    bgReadings.add(bgReading);
+                                }
                                 break;
                             default:
                                 log.debug("Unknown entries type: " + type);
@@ -75,5 +81,7 @@ public class SourceMM640gPlugin extends PluginBase implements BgSourceInterface 
                 }
             }
         }
+
+        return bgReadings;
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
@@ -1,5 +1,7 @@
 package info.nightscout.androidaps.plugins.Source;
 
+import android.os.Bundle;
+
 import info.nightscout.androidaps.Config;
 import info.nightscout.androidaps.R;
 import info.nightscout.androidaps.interfaces.BgSourceInterface;
@@ -31,4 +33,9 @@ public class SourceNSClientPlugin extends PluginBase implements BgSourceInterfac
         );
     }
 
+    @Override
+    public void processNewData(Bundle bundle) {
+        // TODO
+        throw new IllegalStateException("Nope");
+    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
@@ -19,6 +19,7 @@ import info.nightscout.androidaps.interfaces.PluginBase;
 import info.nightscout.androidaps.interfaces.PluginDescription;
 import info.nightscout.androidaps.interfaces.PluginType;
 import info.nightscout.androidaps.plugins.NSClientInternal.data.NSSgv;
+import info.nightscout.utils.JsonHelper;
 
 /**
  * Created by mike on 05.08.2016.
@@ -65,7 +66,9 @@ public class SourceNSClientPlugin extends PluginBase implements BgSourceInterfac
                 for (int i = 0; i < jsonArray.length(); i++) {
                     JSONObject sgvJson = jsonArray.getJSONObject(i);
                     BgReading bgReading = new BgReading(new NSSgv(sgvJson));
-                    bgReading.filtered = false;
+                    String sourceDescription = JsonHelper.safeGetString(sgvJson, "device");
+                    bgReading.filtered = sourceDescription != null
+                            && (sourceDescription.equals("G5 Native") || sourceDescription.equals("AndroidAPS-DexcomG5"));
                     bgReading.sourcePlugin = getName();
                     boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, "NS");
                     if (isNew) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
@@ -67,7 +67,7 @@ public class SourceNSClientPlugin extends PluginBase implements BgSourceInterfac
                     JSONObject sgvJson = jsonArray.getJSONObject(i);
                     BgReading bgReading = new BgReading(new NSSgv(sgvJson));
                     String sourceDescription = JsonHelper.safeGetString(sgvJson, "device");
-                    bgReading.filtered = sourceDescription != null
+                    bgReading.isFiltered = sourceDescription != null
                             && (sourceDescription.contains("G5 Native") || sourceDescription.contains("AndroidAPS-DexcomG5"));
                     bgReading.sourcePlugin = getName();
                     boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
@@ -68,7 +68,7 @@ public class SourceNSClientPlugin extends PluginBase implements BgSourceInterfac
                     BgReading bgReading = new BgReading(new NSSgv(sgvJson));
                     String sourceDescription = JsonHelper.safeGetString(sgvJson, "device");
                     bgReading.filtered = sourceDescription != null
-                            && (sourceDescription.equals("G5 Native") || sourceDescription.equals("AndroidAPS-DexcomG5"));
+                            && (sourceDescription.contains("G5 Native") || sourceDescription.contains("AndroidAPS-DexcomG5"));
                     bgReading.sourcePlugin = getName();
                     boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());
                     if (isNew) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
@@ -65,6 +65,8 @@ public class SourceNSClientPlugin extends PluginBase implements BgSourceInterfac
                 for (int i = 0; i < jsonArray.length(); i++) {
                     JSONObject sgvJson = jsonArray.getJSONObject(i);
                     BgReading bgReading = new BgReading(new NSSgv(sgvJson));
+                    bgReading.filtered = false;
+                    bgReading.sourcePlugin = getName();
                     boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, "NS");
                     if (isNew) {
                         sgvs.add(bgReading);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
@@ -70,7 +70,7 @@ public class SourceNSClientPlugin extends PluginBase implements BgSourceInterfac
                     bgReading.filtered = sourceDescription != null
                             && (sourceDescription.equals("G5 Native") || sourceDescription.equals("AndroidAPS-DexcomG5"));
                     bgReading.sourcePlugin = getName();
-                    boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, "NS");
+                    boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());
                     if (isNew) {
                         sgvs.add(bgReading);
                     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
@@ -20,9 +20,6 @@ public class SourceNSClientPlugin extends PluginBase implements BgSourceInterfac
         return plugin;
     }
 
-    private long lastBGTimeStamp = 0;
-    private boolean isAdvancedFilteringEnabled = false;
-
     private SourceNSClientPlugin() {
         super(new PluginDescription()
                 .mainType(PluginType.BGSOURCE)
@@ -34,18 +31,4 @@ public class SourceNSClientPlugin extends PluginBase implements BgSourceInterfac
         );
     }
 
-    @Override
-    public boolean advancedFilteringSupported() {
-        return isAdvancedFilteringEnabled;
-    }
-
-    public void detectSource(String source, long timeStamp) {
-        if (timeStamp > lastBGTimeStamp) {
-            if (source.contains("G5 Native") || source.contains("AndroidAPS-DexcomG5"))
-                isAdvancedFilteringEnabled = true;
-            else
-                isAdvancedFilteringEnabled = false;
-            lastBGTimeStamp = timeStamp;
-        }
-    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourcePoctechPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourcePoctechPlugin.java
@@ -66,7 +66,7 @@ public class SourcePoctechPlugin extends PluginBase implements BgSourceInterface
                 bgReading.direction = json.getString("direction");
                 bgReading.date = json.getLong("date");
                 bgReading.raw = json.getDouble("raw");
-                bgReading.filtered = false;
+                bgReading.isFiltered = false;
                 bgReading.sourcePlugin = getName();
                 if (JsonHelper.safeGetString(json, "utils", Constants.MGDL).equals("mmol/L"))
                     bgReading.value = bgReading.value * Constants.MMOLL_TO_MGDL;

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourcePoctechPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourcePoctechPlugin.java
@@ -1,16 +1,31 @@
 package info.nightscout.androidaps.plugins.Source;
 
+import android.os.Bundle;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import info.nightscout.androidaps.Config;
+import info.nightscout.androidaps.Constants;
+import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.R;
+import info.nightscout.androidaps.db.BgReading;
 import info.nightscout.androidaps.interfaces.BgSourceInterface;
 import info.nightscout.androidaps.interfaces.PluginBase;
 import info.nightscout.androidaps.interfaces.PluginDescription;
 import info.nightscout.androidaps.interfaces.PluginType;
+import info.nightscout.utils.JsonHelper;
+import info.nightscout.utils.NSUpload;
+import info.nightscout.utils.SP;
 
 /**
  * Created by mike on 05.08.2016.
  */
 public class SourcePoctechPlugin extends PluginBase implements BgSourceInterface {
+    private static final Logger log = LoggerFactory.getLogger(SourcePoctechPlugin.class);
 
     private static SourcePoctechPlugin plugin = null;
 
@@ -31,4 +46,35 @@ public class SourcePoctechPlugin extends PluginBase implements BgSourceInterface
         );
     }
 
+    @Override
+    public void processNewData(Bundle bundle) {
+        BgReading bgReading = new BgReading();
+
+        String data = bundle.getString("data");
+        log.debug("Received Poctech Data", data);
+
+        try {
+            JSONArray jsonArray = new JSONArray(data);
+            log.debug("Received Poctech Data size:" + jsonArray.length());
+            for (int i = 0; i < jsonArray.length(); i++) {
+                JSONObject json = jsonArray.getJSONObject(i);
+                bgReading.value = json.getDouble("current");
+                bgReading.direction = json.getString("direction");
+                bgReading.date = json.getLong("date");
+                bgReading.raw = json.getDouble("raw");
+                if (JsonHelper.safeGetString(json, "utils", Constants.MGDL).equals("mmol/L"))
+                    bgReading.value = bgReading.value * Constants.MMOLL_TO_MGDL;
+                boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, "Poctech");
+                if (isNew && SP.getBoolean(R.string.key_dexcomg5_nsupload, false)) {
+                    NSUpload.uploadBg(bgReading);
+                }
+                if (isNew && SP.getBoolean(R.string.key_dexcomg5_xdripupload, false)) {
+                    NSUpload.sendToXdrip(bgReading);
+                }
+            }
+
+        } catch (JSONException e) {
+            log.error("Unhandled exception", e);
+        }
+    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourcePoctechPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourcePoctechPlugin.java
@@ -66,6 +66,8 @@ public class SourcePoctechPlugin extends PluginBase implements BgSourceInterface
                 bgReading.direction = json.getString("direction");
                 bgReading.date = json.getLong("date");
                 bgReading.raw = json.getDouble("raw");
+                bgReading.filtered = false;
+                bgReading.sourcePlugin = getName();
                 if (JsonHelper.safeGetString(json, "utils", Constants.MGDL).equals("mmol/L"))
                     bgReading.value = bgReading.value * Constants.MMOLL_TO_MGDL;
                 boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourcePoctechPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourcePoctechPlugin.java
@@ -31,9 +31,4 @@ public class SourcePoctechPlugin extends PluginBase implements BgSourceInterface
         );
     }
 
-    @Override
-    public boolean advancedFilteringSupported() {
-        return false;
-    }
-
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
@@ -54,6 +54,8 @@ public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
         String sourceDescription = bundle.getString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION, "");
         bgReading.filtered = sourceDescription.equals("G5 Native");
         if (MainApp.engineeringMode && !bgReading.filtered && bgReading.noise >= 0 && bgReading.noise <= 4) {
+            // TODO syncing noice with NS is neither implemented nor tested
+            // * NSUpload.uploadBg
             log.debug("Setting filtered=true, since noise is provided and passed check: " + bgReading.noise);
             bgReading.filtered = true;
         }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
@@ -50,15 +50,8 @@ public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
         bgReading.direction = bundle.getString(Intents.EXTRA_BG_SLOPE_NAME);
         bgReading.date = bundle.getLong(Intents.EXTRA_TIMESTAMP);
         bgReading.raw = bundle.getDouble(Intents.EXTRA_RAW);
-        bgReading.noise = bundle.getDouble(Intents.EXTRA_NOISE, -999);
         String sourceDescription = bundle.getString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION, "");
         bgReading.isFiltered = sourceDescription.equals("G5 Native");
-        if (MainApp.engineeringMode && !bgReading.isFiltered && bgReading.noise >= 0 && bgReading.noise <= 4) {
-            // TODO syncing noice with NS is neither implemented nor tested
-            // * NSUpload.uploadBg
-            log.debug("Setting filtered=true, since noise is provided and passed check: " + bgReading.noise);
-            bgReading.isFiltered = true;
-        }
         bgReading.sourcePlugin = getName();
 
         boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
@@ -47,7 +47,8 @@ public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
         bgReading.direction = bundle.getString(Intents.EXTRA_BG_SLOPE_NAME);
         bgReading.date = bundle.getLong(Intents.EXTRA_TIMESTAMP);
         bgReading.raw = bundle.getDouble(Intents.EXTRA_RAW);
-        bgReading.filtered = Objects.equals(bundle.getString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION), "G5 Native");
+        String sourceDescription = bundle.getString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION, "");
+        bgReading.filtered = sourceDescription.equals("G5 Native") || sourceDescription.equals("AndroidAPS-DexcomG5");
         bgReading.sourcePlugin = getName();
 
         boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
@@ -13,8 +13,6 @@ public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
 
     private static SourceXdripPlugin plugin = null;
     
-    boolean advancedFiltering;
-
     public static SourceXdripPlugin getPlugin() {
         if (plugin == null)
             plugin = new SourceXdripPlugin();
@@ -28,14 +26,5 @@ public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
                 .pluginName(R.string.xdrip)
                 .description(R.string.description_source_xdrip)
         );
-    }
-
-    @Override
-    public boolean advancedFilteringSupported() {
-        return advancedFiltering;
-    }
-
-    public void setSource(String source) {
-        this.advancedFiltering = source.contains("G5 Native");
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
@@ -6,7 +6,6 @@ import com.google.common.collect.Lists;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.R;
@@ -23,7 +22,7 @@ import info.nightscout.androidaps.interfaces.PluginType;
 public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
 
     private static SourceXdripPlugin plugin = null;
-    
+
     public static SourceXdripPlugin getPlugin() {
         if (plugin == null)
             plugin = new SourceXdripPlugin();
@@ -48,7 +47,7 @@ public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
         bgReading.date = bundle.getLong(Intents.EXTRA_TIMESTAMP);
         bgReading.raw = bundle.getDouble(Intents.EXTRA_RAW);
         String sourceDescription = bundle.getString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION, "");
-        bgReading.filtered = sourceDescription.equals("G5 Native") || sourceDescription.equals("AndroidAPS-DexcomG5");
+        bgReading.filtered = sourceDescription.equals("G5 Native");
         bgReading.sourcePlugin = getName();
 
         boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
@@ -1,6 +1,13 @@
 package info.nightscout.androidaps.plugins.Source;
 
+import android.os.Bundle;
+
+import java.util.Objects;
+
+import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.R;
+import info.nightscout.androidaps.Services.Intents;
+import info.nightscout.androidaps.db.BgReading;
 import info.nightscout.androidaps.interfaces.BgSourceInterface;
 import info.nightscout.androidaps.interfaces.PluginBase;
 import info.nightscout.androidaps.interfaces.PluginDescription;
@@ -26,5 +33,19 @@ public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
                 .pluginName(R.string.xdrip)
                 .description(R.string.description_source_xdrip)
         );
+    }
+
+    @Override
+    public void processNewData(Bundle bundle) {
+        BgReading bgReading = new BgReading();
+
+        bgReading.value = bundle.getDouble(Intents.EXTRA_BG_ESTIMATE);
+        bgReading.direction = bundle.getString(Intents.EXTRA_BG_SLOPE_NAME);
+        bgReading.date = bundle.getLong(Intents.EXTRA_TIMESTAMP);
+        bgReading.raw = bundle.getDouble(Intents.EXTRA_RAW);
+        bgReading.sourcePlugin = SourceXdripPlugin.getPlugin().getName();
+        bgReading.filtered = Objects.equals(bundle.getString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION), "G5 Native");
+
+        MainApp.getDbHelper().createIfNotExists(bgReading, "XDRIP");
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
@@ -4,6 +4,9 @@ import android.os.Bundle;
 
 import com.google.common.collect.Lists;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -20,6 +23,7 @@ import info.nightscout.androidaps.interfaces.PluginType;
  * Created by mike on 05.08.2016.
  */
 public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
+    private static final Logger log = LoggerFactory.getLogger(SourceXdripPlugin.class);
 
     private static SourceXdripPlugin plugin = null;
 
@@ -46,8 +50,13 @@ public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
         bgReading.direction = bundle.getString(Intents.EXTRA_BG_SLOPE_NAME);
         bgReading.date = bundle.getLong(Intents.EXTRA_TIMESTAMP);
         bgReading.raw = bundle.getDouble(Intents.EXTRA_RAW);
+        bgReading.noise = bundle.getDouble(Intents.EXTRA_NOISE, -999);
         String sourceDescription = bundle.getString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION, "");
         bgReading.filtered = sourceDescription.equals("G5 Native");
+        if (MainApp.engineeringMode && !bgReading.filtered && bgReading.noise >= 0 && bgReading.noise <= 4) {
+            log.debug("Setting filtered=true, since noise is provided and passed check: " + bgReading.noise);
+            bgReading.filtered = true;
+        }
         bgReading.sourcePlugin = getName();
 
         boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
@@ -47,8 +47,8 @@ public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
         bgReading.direction = bundle.getString(Intents.EXTRA_BG_SLOPE_NAME);
         bgReading.date = bundle.getLong(Intents.EXTRA_TIMESTAMP);
         bgReading.raw = bundle.getDouble(Intents.EXTRA_RAW);
-        bgReading.sourcePlugin = SourceXdripPlugin.getPlugin().getName();
         bgReading.filtered = Objects.equals(bundle.getString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION), "G5 Native");
+        bgReading.sourcePlugin = getName();
 
         boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());
         return isNew ? Lists.newArrayList(bgReading) : Collections.emptyList();

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
@@ -52,12 +52,12 @@ public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
         bgReading.raw = bundle.getDouble(Intents.EXTRA_RAW);
         bgReading.noise = bundle.getDouble(Intents.EXTRA_NOISE, -999);
         String sourceDescription = bundle.getString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION, "");
-        bgReading.filtered = sourceDescription.equals("G5 Native");
-        if (MainApp.engineeringMode && !bgReading.filtered && bgReading.noise >= 0 && bgReading.noise <= 4) {
+        bgReading.isFiltered = sourceDescription.equals("G5 Native");
+        if (MainApp.engineeringMode && !bgReading.isFiltered && bgReading.noise >= 0 && bgReading.noise <= 4) {
             // TODO syncing noice with NS is neither implemented nor tested
             // * NSUpload.uploadBg
             log.debug("Setting filtered=true, since noise is provided and passed check: " + bgReading.noise);
-            bgReading.filtered = true;
+            bgReading.isFiltered = true;
         }
         bgReading.sourcePlugin = getName();
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceXdripPlugin.java
@@ -2,6 +2,10 @@ package info.nightscout.androidaps.plugins.Source;
 
 import android.os.Bundle;
 
+import com.google.common.collect.Lists;
+
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import info.nightscout.androidaps.MainApp;
@@ -36,7 +40,7 @@ public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
     }
 
     @Override
-    public void processNewData(Bundle bundle) {
+    public List<BgReading> processNewData(Bundle bundle) {
         BgReading bgReading = new BgReading();
 
         bgReading.value = bundle.getDouble(Intents.EXTRA_BG_ESTIMATE);
@@ -46,6 +50,7 @@ public class SourceXdripPlugin extends PluginBase implements BgSourceInterface {
         bgReading.sourcePlugin = SourceXdripPlugin.getPlugin().getName();
         bgReading.filtered = Objects.equals(bundle.getString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION), "G5 Native");
 
-        MainApp.getDbHelper().createIfNotExists(bgReading, "XDRIP");
+        boolean isNew = MainApp.getDbHelper().createIfNotExists(bgReading, getName());
+        return isNew ? Lists.newArrayList(bgReading) : Collections.emptyList();
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/queue/CommandQueue.java
+++ b/app/src/main/java/info/nightscout/androidaps/queue/CommandQueue.java
@@ -180,7 +180,7 @@ public class CommandQueue {
 
         if (type == Command.CommandType.SMB_BOLUS) {
             if (isRunning(Command.CommandType.BOLUS) || bolusInQueue()) {
-                log.debug("Rejecting SMB since a bolus is queue/running");
+                log.debug("Rejecting SMB since a bolus is queued/running");
                 return false;
             }
             if (detailedBolusInfo.lastKnownBolusTime < TreatmentsPlugin.getPlugin().getLastBolusTime()) {

--- a/app/src/main/java/info/nightscout/utils/NSUpload.java
+++ b/app/src/main/java/info/nightscout/utils/NSUpload.java
@@ -469,6 +469,8 @@ public class NSUpload {
             data.put("sgv", reading.value);
             data.put("direction", reading.direction);
             data.put("type", "sgv");
+            data.put("isFiltered", reading.isFiltered);
+            data.put("sourcePlugin", reading.sourcePlugin);
         } catch (JSONException e) {
             log.error("Unhandled exception", e);
         }

--- a/app/src/test/java/info/nightscout/androidaps/interfaces/ConstraintsCheckerTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/interfaces/ConstraintsCheckerTest.java
@@ -111,15 +111,15 @@ public class ConstraintsCheckerTest {
         Assert.assertEquals(Boolean.FALSE, c.value());
     }
 
-    @Test
-    public void isAdvancedFilteringEnabledTest() throws Exception {
-        when(MainApp.getConfigBuilder().getActiveBgSource()).thenReturn(SourceGlimpPlugin.getPlugin());
-
-        Constraint<Boolean> c = constraintChecker.isAdvancedFilteringEnabled();
-        Assert.assertEquals(true, c.getReasonList().size() == 1); // Safety
-        Assert.assertEquals(true, c.getMostLimitedReasonList().size() == 1); // Safety
-        Assert.assertEquals(Boolean.FALSE, c.value());
-    }
+//    @Test
+//    public void isAdvancedFilteringEnabledTest() throws Exception {
+//        when(MainApp.getConfigBuilder().getActiveBgSource()).thenReturn(SourceGlimpPlugin.getPlugin());
+//
+//        Constraint<Boolean> c = constraintChecker.isAdvancedFilteringEnabled();
+//        Assert.assertEquals(true, c.getReasonList().size() == 1); // Safety
+//        Assert.assertEquals(true, c.getMostLimitedReasonList().size() == 1); // Safety
+//        Assert.assertEquals(Boolean.FALSE, c.value());
+//    }
 
     @Test
     public void isSMBModeEnabledTest() throws Exception {

--- a/app/src/test/java/info/nightscout/androidaps/interfaces/ConstraintsCheckerTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/interfaces/ConstraintsCheckerTest.java
@@ -223,13 +223,14 @@ public class ConstraintsCheckerTest {
         // No limit by default
         when(SP.getDouble(R.string.key_openapsma_max_iob, 1.5d)).thenReturn(1.5d);
         when(SP.getString(R.string.key_age, "")).thenReturn("teenage");
-        OpenAPSMAPlugin.getPlugin().setPluginEnabled(PluginType.APS, true);
         OpenAPSAMAPlugin.getPlugin().setPluginEnabled(PluginType.APS, true);
+        OpenAPSMAPlugin.getPlugin().setPluginEnabled(PluginType.APS, false);
+        OpenAPSSMBPlugin.getPlugin().setPluginEnabled(PluginType.APS, false);
 
         // Apply all limits
         Constraint<Double> d = constraintChecker.getMaxIOBAllowed();
         Assert.assertEquals(1.5d, d.value());
-        Assert.assertEquals(3, d.getReasonList().size());
+        Assert.assertEquals(d.getReasonList().toString(),2, d.getReasonList().size());
         Assert.assertEquals("Safety: Limiting IOB to 1.5 U because of max value in preferences", d.getMostLimitedReasons());
 
     }
@@ -240,11 +241,13 @@ public class ConstraintsCheckerTest {
         when(SP.getDouble(R.string.key_openapssmb_max_iob, 3d)).thenReturn(3d);
         when(SP.getString(R.string.key_age, "")).thenReturn("teenage");
         OpenAPSSMBPlugin.getPlugin().setPluginEnabled(PluginType.APS, true);
+        OpenAPSAMAPlugin.getPlugin().setPluginEnabled(PluginType.APS, false);
+        OpenAPSMAPlugin.getPlugin().setPluginEnabled(PluginType.APS, false);
 
         // Apply all limits
         Constraint<Double> d = constraintChecker.getMaxIOBAllowed();
         Assert.assertEquals(3d, d.value());
-        Assert.assertEquals(4, d.getReasonList().size());
+        Assert.assertEquals(d.getReasonList().toString(), 2, d.getReasonList().size());
         Assert.assertEquals("Safety: Limiting IOB to 3.0 U because of max value in preferences", d.getMostLimitedReasons());
 
     }

--- a/app/src/test/java/info/nightscout/androidaps/interfaces/ConstraintsCheckerTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/interfaces/ConstraintsCheckerTest.java
@@ -111,16 +111,6 @@ public class ConstraintsCheckerTest {
         Assert.assertEquals(Boolean.FALSE, c.value());
     }
 
-//    @Test
-//    public void isAdvancedFilteringEnabledTest() throws Exception {
-//        when(MainApp.getConfigBuilder().getActiveBgSource()).thenReturn(SourceGlimpPlugin.getPlugin());
-//
-//        Constraint<Boolean> c = constraintChecker.isAdvancedFilteringEnabled();
-//        Assert.assertEquals(true, c.getReasonList().size() == 1); // Safety
-//        Assert.assertEquals(true, c.getMostLimitedReasonList().size() == 1); // Safety
-//        Assert.assertEquals(Boolean.FALSE, c.value());
-//    }
-
     @Test
     public void isSMBModeEnabledTest() throws Exception {
         objectivesPlugin.objectives.get(7).setStartedOn(null);

--- a/app/src/test/java/info/nightscout/androidaps/plugins/ConstraintsSafety/SafetyPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/ConstraintsSafety/SafetyPluginTest.java
@@ -89,17 +89,6 @@ public class SafetyPluginTest {
         Assert.assertEquals(Boolean.FALSE, c.value());
     }
 
-    // TODO
-//    @Test
-//    public void bgsourceShouldPreventSMBAlways() throws Exception {
-//        when(MainApp.getConfigBuilder().getActiveBgSource()).thenReturn(SourceGlimpPlugin.getPlugin());
-//
-//        Constraint<Boolean> c = new Constraint<>(true);
-//        c = safetyPlugin.isAdvancedFilteringEnabled(c);
-//        Assert.assertEquals("Safety: SMB always and after carbs disabled because active BG source doesn\\'t support advanced filtering", c.getReasons());
-//        Assert.assertEquals(Boolean.FALSE, c.value());
-//    }
-
     @Test
     public void basalRateShouldBeLimited() throws Exception {
         when(SP.getDouble(R.string.key_openapsma_max_basal, 1d)).thenReturn(1d);

--- a/app/src/test/java/info/nightscout/androidaps/plugins/ConstraintsSafety/SafetyPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/ConstraintsSafety/SafetyPluginTest.java
@@ -89,15 +89,16 @@ public class SafetyPluginTest {
         Assert.assertEquals(Boolean.FALSE, c.value());
     }
 
-    @Test
-    public void bgsourceShouldPreventSMBAlways() throws Exception {
-        when(MainApp.getConfigBuilder().getActiveBgSource()).thenReturn(SourceGlimpPlugin.getPlugin());
-
-        Constraint<Boolean> c = new Constraint<>(true);
-        c = safetyPlugin.isAdvancedFilteringEnabled(c);
-        Assert.assertEquals("Safety: SMB always and after carbs disabled because active BG source doesn\\'t support advanced filtering", c.getReasons());
-        Assert.assertEquals(Boolean.FALSE, c.value());
-    }
+    // TODO
+//    @Test
+//    public void bgsourceShouldPreventSMBAlways() throws Exception {
+//        when(MainApp.getConfigBuilder().getActiveBgSource()).thenReturn(SourceGlimpPlugin.getPlugin());
+//
+//        Constraint<Boolean> c = new Constraint<>(true);
+//        c = safetyPlugin.isAdvancedFilteringEnabled(c);
+//        Assert.assertEquals("Safety: SMB always and after carbs disabled because active BG source doesn\\'t support advanced filtering", c.getReasons());
+//        Assert.assertEquals(Boolean.FALSE, c.value());
+//    }
 
     @Test
     public void basalRateShouldBeLimited() throws Exception {

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceDexcomG5PluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceDexcomG5PluginTest.java
@@ -15,8 +15,8 @@ public class SourceDexcomG5PluginTest {
         Assert.assertNotEquals(null, SourceDexcomG5Plugin.getPlugin());
     }
 
-    @Test
-    public void advancedFilteringSupported() {
-        Assert.assertEquals(true, SourceDexcomG5Plugin.getPlugin().advancedFilteringSupported());
-    }
+//    @Test
+//    public void advancedFilteringSupported() {
+//        Assert.assertEquals(true, SourceDexcomG5Plugin.getPlugin().advancedFilteringSupported());
+//    }
 }

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceDexcomG5PluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceDexcomG5PluginTest.java
@@ -14,9 +14,4 @@ public class SourceDexcomG5PluginTest {
     public void getPlugin() {
         Assert.assertNotEquals(null, SourceDexcomG5Plugin.getPlugin());
     }
-
-//    @Test
-//    public void advancedFilteringSupported() {
-//        Assert.assertEquals(true, SourceDexcomG5Plugin.getPlugin().advancedFilteringSupported());
-//    }
 }

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPluginTest.java
@@ -14,9 +14,4 @@ public class SourceGlimpPluginTest {
     public void getPlugin() {
         Assert.assertNotEquals(null, SourceGlimpPlugin.getPlugin());
     }
-
-//    @Test
-//    public void advancedFilteringSupported() {
-//        Assert.assertEquals(false, SourceGlimpPlugin.getPlugin().advancedFilteringSupported());
-//    }
 }

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceGlimpPluginTest.java
@@ -15,8 +15,8 @@ public class SourceGlimpPluginTest {
         Assert.assertNotEquals(null, SourceGlimpPlugin.getPlugin());
     }
 
-    @Test
-    public void advancedFilteringSupported() {
-        Assert.assertEquals(false, SourceGlimpPlugin.getPlugin().advancedFilteringSupported());
-    }
+//    @Test
+//    public void advancedFilteringSupported() {
+//        Assert.assertEquals(false, SourceGlimpPlugin.getPlugin().advancedFilteringSupported());
+//    }
 }

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceMM640gPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceMM640gPluginTest.java
@@ -15,8 +15,8 @@ public class SourceMM640gPluginTest {
         Assert.assertNotEquals(null, SourceMM640gPlugin.getPlugin());
     }
 
-    @Test
-    public void advancedFilteringSupported() {
-        Assert.assertEquals(false, SourceMM640gPlugin.getPlugin().advancedFilteringSupported());
-    }
+//    @Test
+//    public void advancedFilteringSupported() {
+//        Assert.assertEquals(false, SourceMM640gPlugin.getPlugin().advancedFilteringSupported());
+//    }
 }

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceMM640gPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceMM640gPluginTest.java
@@ -14,9 +14,4 @@ public class SourceMM640gPluginTest {
     public void getPlugin() {
         Assert.assertNotEquals(null, SourceMM640gPlugin.getPlugin());
     }
-
-//    @Test
-//    public void advancedFilteringSupported() {
-//        Assert.assertEquals(false, SourceMM640gPlugin.getPlugin().advancedFilteringSupported());
-//    }
 }

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPluginTest.java
@@ -13,8 +13,8 @@ public class SourceNSClientPluginTest {
         Assert.assertNotEquals(null, SourceNSClientPlugin.getPlugin());
     }
 
-    @Test
-    public void advancedFilteringSupported() {
-        Assert.assertEquals(false, SourceNSClientPlugin.getPlugin().advancedFilteringSupported());
-    }
+//    @Test
+//    public void advancedFilteringSupported() {
+//        Assert.assertEquals(false, SourceNSClientPlugin.getPlugin().advancedFilteringSupported());
+//    }
 }

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPluginTest.java
@@ -12,9 +12,4 @@ public class SourceNSClientPluginTest {
     public void getPlugin() {
         Assert.assertNotEquals(null, SourceNSClientPlugin.getPlugin());
     }
-
-//    @Test
-//    public void advancedFilteringSupported() {
-//        Assert.assertEquals(false, SourceNSClientPlugin.getPlugin().advancedFilteringSupported());
-//    }
 }

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceXdripPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceXdripPluginTest.java
@@ -1,22 +1,75 @@
 package info.nightscout.androidaps.plugins.Source;
 
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import info.nightscout.androidaps.plugins.Source.SourceXdripPlugin;
+import info.nightscout.androidaps.MainApp;
+import info.nightscout.androidaps.Services.Intents;
+import info.nightscout.androidaps.db.BgReading;
+import info.nightscout.androidaps.db.DatabaseHelper;
+
+import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
+@PrepareForTest({MainApp.class, DatabaseHelper.class})
 public class SourceXdripPluginTest {
 
+    private SourceXdripPlugin plugin = SourceXdripPlugin.getPlugin();
+
+    @Before
+    public void prepareTest() {
+        PowerMockito.mockStatic(MainApp.class);
+        when(MainApp.gs(0)).thenReturn("");
+        DatabaseHelper databaseHelper = mock(DatabaseHelper.class);
+        when(MainApp.getDbHelper()).thenReturn(databaseHelper);
+        when(databaseHelper.createIfNotExists(any(), any())).thenReturn(true);
+    }
+
     @Test
-    public void getPlugin() {
+    public void pluginInitializes() {
         Assert.assertNotEquals(null, SourceXdripPlugin.getPlugin());
     }
 
-//    @Test
-//    public void advancedFilteringSupported() {
-//        Assert.assertEquals(false, SourceXdripPlugin.getPlugin().advancedFilteringSupported());
-//    }
+    // TODO
+    @Ignore("Bundle needs to be properly mocked")
+    @Test
+    public void bgWithUnknownSourceIsMarkedUnfiltered() {
+        Bundle bundle = createBroadcastBundle();
+        BgReading bgReadings = plugin.processNewData(bundle).get(0);
+        assertFalse(bgReadings.filtered);
+    }
+
+    // TODO
+    @Ignore("Bundle needs to be properly mocked")
+    @Test
+    public void bgWithSourceG5NativeIsMarkedFiltered() {
+        Bundle bundle = createBroadcastBundle();
+        bundle.putString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION, "G5 Native");
+
+        BgReading bgReadings = plugin.processNewData(bundle).get(0);
+        assertTrue(bgReadings.filtered);
+    }
+
+    @NonNull
+    private Bundle createBroadcastBundle() {
+        Bundle bundle = new Bundle();
+        bundle.putDouble(Intents.EXTRA_BG_ESTIMATE, 100.0);
+        bundle.putString(Intents.EXTRA_BG_SLOPE_NAME, "DoubleDown");
+        bundle.putLong(Intents.EXTRA_TIMESTAMP, 0L);
+        bundle.putDouble(Intents.EXTRA_RAW, 430.0);
+        return bundle;
+    }
 }

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceXdripPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceXdripPluginTest.java
@@ -44,7 +44,7 @@ public class SourceXdripPluginTest {
     }
 
     // TODO
-    @Ignore("Bundle needs to be properly mocked")
+    @Ignore("Bundle needs to be properly mocked or Robolectrics issues with SQLite resolved")
     @Test
     public void bgWithUnknownSourceIsMarkedUnfiltered() {
         Bundle bundle = createBroadcastBundle();
@@ -53,11 +53,33 @@ public class SourceXdripPluginTest {
     }
 
     // TODO
-    @Ignore("Bundle needs to be properly mocked")
+    @Ignore("Bundle needs to be properly mocked or Robolectrics issues with SQLite resolved")
     @Test
     public void bgWithSourceG5NativeIsMarkedFiltered() {
         Bundle bundle = createBroadcastBundle();
         bundle.putString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION, "G5 Native");
+
+        BgReading bgReadings = plugin.processNewData(bundle).get(0);
+        assertTrue(bgReadings.filtered);
+    }
+
+    // TODO
+    @Ignore("Bundle needs to be properly mocked or Robolectrics issues with SQLite resolved")
+    @Test
+    public void bgWithWithGoodNoiseIsMarkedFiltered() {
+        Bundle bundle = createBroadcastBundle();
+        bundle.putString(Intents.EXTRA_NOISE, "1.0");
+
+        BgReading bgReadings = plugin.processNewData(bundle).get(0);
+        assertTrue(bgReadings.filtered);
+    }
+
+    // TODO
+    @Ignore("Bundle needs to be properly mocked or Robolectrics issues with SQLite resolved")
+    @Test
+    public void bgWithWithExcessiveNoiseDataIsMarkedFiltered() {
+        Bundle bundle = createBroadcastBundle();
+        bundle.putString(Intents.EXTRA_NOISE, "80.0");
 
         BgReading bgReadings = plugin.processNewData(bundle).get(0);
         assertTrue(bgReadings.filtered);

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceXdripPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceXdripPluginTest.java
@@ -49,7 +49,7 @@ public class SourceXdripPluginTest {
     public void bgWithUnknownSourceIsMarkedUnfiltered() {
         Bundle bundle = createBroadcastBundle();
         BgReading bgReadings = plugin.processNewData(bundle).get(0);
-        assertFalse(bgReadings.filtered);
+        assertFalse(bgReadings.isFiltered);
     }
 
     // TODO
@@ -60,7 +60,7 @@ public class SourceXdripPluginTest {
         bundle.putString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION, "G5 Native");
 
         BgReading bgReadings = plugin.processNewData(bundle).get(0);
-        assertTrue(bgReadings.filtered);
+        assertTrue(bgReadings.isFiltered);
     }
 
     // TODO
@@ -71,7 +71,7 @@ public class SourceXdripPluginTest {
         bundle.putString(Intents.EXTRA_NOISE, "1.0");
 
         BgReading bgReadings = plugin.processNewData(bundle).get(0);
-        assertTrue(bgReadings.filtered);
+        assertTrue(bgReadings.isFiltered);
     }
 
     // TODO
@@ -82,7 +82,7 @@ public class SourceXdripPluginTest {
         bundle.putString(Intents.EXTRA_NOISE, "80.0");
 
         BgReading bgReadings = plugin.processNewData(bundle).get(0);
-        assertTrue(bgReadings.filtered);
+        assertTrue(bgReadings.isFiltered);
     }
 
     @NonNull

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceXdripPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceXdripPluginTest.java
@@ -63,6 +63,7 @@ public class SourceXdripPluginTest {
         assertTrue(bgReadings.isFiltered);
     }
 
+    /*
     // TODO
     @Ignore("Bundle needs to be properly mocked or Robolectrics issues with SQLite resolved")
     @Test
@@ -84,6 +85,7 @@ public class SourceXdripPluginTest {
         BgReading bgReadings = plugin.processNewData(bundle).get(0);
         assertTrue(bgReadings.isFiltered);
     }
+    */
 
     @NonNull
     private Bundle createBroadcastBundle() {

--- a/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceXdripPluginTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/Source/SourceXdripPluginTest.java
@@ -15,8 +15,8 @@ public class SourceXdripPluginTest {
         Assert.assertNotEquals(null, SourceXdripPlugin.getPlugin());
     }
 
-    @Test
-    public void advancedFilteringSupported() {
-        Assert.assertEquals(false, SourceXdripPlugin.getPlugin().advancedFilteringSupported());
-    }
+//    @Test
+//    public void advancedFilteringSupported() {
+//        Assert.assertEquals(false, SourceXdripPlugin.getPlugin().advancedFilteringSupported());
+//    }
 }


### PR DESCRIPTION
Previously I attempted to add the source of a BG to an Event informing the loop about a new BG, but that didn't work out, because the BG sent from xDrip was cancelled out by the same value doing a roundtrip to NS (DatabaseHelper.scheduleBgChange), which lead to the loop not being invoked at all.

The approach taken here is in line with how events are used in AAPS in most cases: just send out an event, notificating interested parties that **something** happened and letting the receiver fetch all relevant data to make a decision himself.

To that end, I've added add _sourcePlugin_ and _isFiltered_ field to _BgReading_. 
The relevant columns are added to the DB if they don't exist. This "soft migrates" the schema without touching the DB schema/version. Going back to a previous AAPS version will simply ignore the additional columns.

_sourcePlugin_ is then used by the loop to determine whether to loop with a BG.

_isFiltered_ is used to determine whether we can enable advanced SMB features. This superseedes _BgInterface.advancedFilteringSuppored_, which was messy since xDrip is kind of a meta-source that can deliver filtered and unfiltered data.

I've moved the processing of new BG intents from _DataServices_ to _BgSource.processNewData_ to make _DataService_ delegate more to the concrete source plugin. Later, it might be worth investigating to push this further to move the (non-BG) NS data processing out of _DataService_ (into _NSClientSomething_), so _DataService_ can focus on its core responsibility of forwarding data to a specific handler.

W.r.t. to tests: since _BgSource.processNewData_ returns the newly created data, this can be nicely tested in a unit test, in theory. However, currently _Bundle_ is a dummy class in a test env, which either needs to be extensively mocked or tested with Robolectrics. With the later, there are other issues (on that we probably shouldn't override _MainApp.onTerminate_), but there are still issues. 

As a proof-of-concept for the refactoring, I've added code to set _isFiltered_ based on noise data if provided by xDrip (engineering mode only). (Reverted since not integrated with NS yet).

What I'm not yet sure about is syncing the new fields in _BgReading_ to NS and back ... at this point though (without noise processing via AAPS), the uploaded extra fields are just informative.

P.S. This is probably easier to review when comparing branches in AS.