### PR TITLE
Rs sync warn

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRS/services/DanaRSService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRS/services/DanaRSService.java
@@ -153,9 +153,6 @@ public class DanaRSService extends Service {
                 long timeDiff = (danaRPump.pumpTime.getTime() - System.currentTimeMillis()) / 1000L;
                 log.debug("Pump time difference: " + timeDiff + " seconds");
                 if (Math.abs(timeDiff) > 3) {
-                    waitForWholeMinute(); // Dana can set only whole minute
-                    // add 10sec to be sure we are over minute (will be cutted off anyway)
-                    bleComm.sendMessage(new DanaRS_Packet_Option_Set_Pump_Time(new Date(DateUtil.now() + T.secs(10).msecs())));
                     if (Math.abs(timeDiff) > 60*60*1.5) {
                         //If time-diff is very large, warn user until we can synchronize history readings properly
                         Intent i = new Intent(MainApp.instance(), ErrorHelperActivity.class);
@@ -164,10 +161,14 @@ public class DanaRSService extends Service {
                         i.putExtra("title", MainApp.gs(R.string.largetimedifftitle));
                         i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         MainApp.instance().startActivity(i);
+                    } else {
+                        waitForWholeMinute(); // Dana can set only whole minute
+                        // add 10sec to be sure we are over minute (will be cutted off anyway)
+                        bleComm.sendMessage(new DanaRS_Packet_Option_Set_Pump_Time(new Date(DateUtil.now() + T.secs(10).msecs())));
+                        bleComm.sendMessage(new DanaRS_Packet_Option_Get_Pump_Time());
+                        timeDiff = (danaRPump.pumpTime.getTime() - System.currentTimeMillis()) / 1000L;
+                        log.debug("Pump time difference: " + timeDiff + " seconds");
                     }
-                    bleComm.sendMessage(new DanaRS_Packet_Option_Get_Pump_Time());
-                    timeDiff = (danaRPump.pumpTime.getTime() - System.currentTimeMillis()) / 1000L;
-                    log.debug("Pump time difference: " + timeDiff + " seconds");
                 }
                 danaRPump.lastSettingsRead = now;
             }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRS/services/DanaRSService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRS/services/DanaRSService.java
@@ -154,6 +154,7 @@ public class DanaRSService extends Service {
                 log.debug("Pump time difference: " + timeDiff + " seconds");
                 if (Math.abs(timeDiff) > 3) {
                     if (Math.abs(timeDiff) > 60*60*1.5) {
+                        log.debug("Pump time difference: " + timeDiff + " seconds - large difference");
                         //If time-diff is very large, warn user until we can synchronize history readings properly
                         Intent i = new Intent(MainApp.instance(), ErrorHelperActivity.class);
                         i.putExtra("soundid", R.raw.error);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRS/services/DanaRSService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRS/services/DanaRSService.java
@@ -19,6 +19,7 @@ import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.R;
 import info.nightscout.androidaps.data.Profile;
 import info.nightscout.androidaps.data.PumpEnactResult;
+import info.nightscout.androidaps.plugins.Overview.Dialogs.ErrorHelperActivity;
 import info.nightscout.androidaps.plugins.PumpDanaRS.comm.DanaRS_Packet_Option_Get_User_Option;
 import info.nightscout.androidaps.plugins.Treatments.Treatment;
 import info.nightscout.androidaps.events.EventAppExit;
@@ -155,6 +156,15 @@ public class DanaRSService extends Service {
                     waitForWholeMinute(); // Dana can set only whole minute
                     // add 10sec to be sure we are over minute (will be cutted off anyway)
                     bleComm.sendMessage(new DanaRS_Packet_Option_Set_Pump_Time(new Date(DateUtil.now() + T.secs(10).msecs())));
+                    if (Math.abs(timeDiff) > 60*60*1.5) {
+                        //If time-diff is very large, warn user until we can synchronize history readings properly
+                        Intent i = new Intent(MainApp.instance(), ErrorHelperActivity.class);
+                        i.putExtra("soundid", R.raw.error);
+                        i.putExtra("status", MainApp.gs(R.string.largetimediff));
+                        i.putExtra("title", MainApp.gs(R.string.largetimedifftitle));
+                        i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        MainApp.instance().startActivity(i);
+                    }
                     bleComm.sendMessage(new DanaRS_Packet_Option_Get_Pump_Time());
                     timeDiff = (danaRPump.pumpTime.getTime() - System.currentTimeMillis()) / 1000L;
                     log.debug("Pump time difference: " + timeDiff + " seconds");

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRS/services/DanaRSService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRS/services/DanaRSService.java
@@ -153,8 +153,7 @@ public class DanaRSService extends Service {
                     MainApp.instance().startActivity(i);
 
                     //deinitialize pump
-                    DanaRPump.reset();
-                    danaRPump =  DanaRPump.getInstance();
+                    danaRPump.lastConnection = 0;
                     MainApp.bus().post(new EventDanaRNewStatus());
                     MainApp.bus().post(new EventInitializationChanged());
                     return;
@@ -167,6 +166,7 @@ public class DanaRSService extends Service {
                     log.debug("Pump time difference: " + timeDiff + " seconds");
                 }
             }
+            danaRPump.lastConnection = System.currentTimeMillis();
 
             long now = System.currentTimeMillis();
             if (danaRPump.lastSettingsRead + 60 * 60 * 1000L < now || !MainApp.getSpecificPlugin(DanaRSPlugin.class).isInitialized()) {
@@ -203,6 +203,13 @@ public class DanaRSService extends Service {
     }
 
     public PumpEnactResult loadEvents() {
+
+        if(!MainApp.getSpecificPlugin(DanaRSPlugin.class).isInitialized()){
+            PumpEnactResult result = new PumpEnactResult().success(false);
+            result.comment = "pump not initialized";
+            return result;
+        }
+
         DanaRS_Packet_APS_History_Events msg;
         if (lastHistoryFetched == 0) {
             msg = new DanaRS_Packet_APS_History_Events(0);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRv2/services/DanaRv2ExecutionService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRv2/services/DanaRv2ExecutionService.java
@@ -205,8 +205,7 @@ public class DanaRv2ExecutionService extends AbstractDanaRExecutionService {
                     MainApp.instance().startActivity(i);
 
                     //deinitialize pump
-                    DanaRPump.reset();
-                    mDanaRPump = DanaRPump.getInstance();
+                    mDanaRPump.lastConnection = 0;
                     MainApp.bus().post(new EventDanaRNewStatus());
                     MainApp.bus().post(new EventInitializationChanged());
                     return;
@@ -219,6 +218,7 @@ public class DanaRv2ExecutionService extends AbstractDanaRExecutionService {
                     log.debug("Pump time difference: " + timeDiff + " seconds");
                 }
             }
+            mDanaRPump.lastConnection = System.currentTimeMillis();
 
             long now = System.currentTimeMillis();
             if (mDanaRPump.lastSettingsRead + 60 * 60 * 1000L < now || !MainApp.getSpecificPlugin(DanaRv2Plugin.class).isInitialized()) {
@@ -445,6 +445,14 @@ public class DanaRv2ExecutionService extends AbstractDanaRExecutionService {
     }
 
     public PumpEnactResult loadEvents() {
+
+        if(!MainApp.getSpecificPlugin(DanaRv2Plugin.class).isInitialized()){
+            PumpEnactResult result = new PumpEnactResult().success(false);
+            result.comment = "pump not initialized";
+            return result;
+        }
+        
+        
         if (!isConnected())
             return new PumpEnactResult().success(false);
         SystemClock.sleep(300);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRv2/services/DanaRv2ExecutionService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRv2/services/DanaRv2ExecutionService.java
@@ -209,10 +209,8 @@ public class DanaRv2ExecutionService extends AbstractDanaRExecutionService {
                 long timeDiff = (mDanaRPump.pumpTime.getTime() - System.currentTimeMillis()) / 1000L;
                 log.debug("Pump time difference: " + timeDiff + " seconds");
                 if (Math.abs(timeDiff) > 3) {
-                    waitForWholeMinute(); // Dana can set only whole minute
-                    // add 10sec to be sure we are over minute (will be cutted off anyway)
-                    mSerialIOThread.sendMessage(new MsgSetTime(new Date(DateUtil.now() + T.secs(10).msecs())));
                     if (Math.abs(timeDiff) > 60*60*1.5) {
+                        log.debug("Pump time difference: " + timeDiff + " seconds - large difference");
                         //If time-diff is very large, warn user until we can synchronize history readings properly
                         Intent i = new Intent(MainApp.instance(), ErrorHelperActivity.class);
                         i.putExtra("soundid", R.raw.error);
@@ -220,10 +218,14 @@ public class DanaRv2ExecutionService extends AbstractDanaRExecutionService {
                         i.putExtra("title", MainApp.gs(R.string.largetimedifftitle));
                         i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         MainApp.instance().startActivity(i);
+                    } else {
+                        waitForWholeMinute(); // Dana can set only whole minute
+                        // add 10sec to be sure we are over minute (will be cutted off anyway)
+                        mSerialIOThread.sendMessage(new MsgSetTime(new Date(DateUtil.now() + T.secs(10).msecs())));
+                        mSerialIOThread.sendMessage(new MsgSettingPumpTime());
+                        timeDiff = (mDanaRPump.pumpTime.getTime() - System.currentTimeMillis()) / 1000L;
+                        log.debug("Pump time difference: " + timeDiff + " seconds");
                     }
-                    mSerialIOThread.sendMessage(new MsgSettingPumpTime());
-                    timeDiff = (mDanaRPump.pumpTime.getTime() - System.currentTimeMillis()) / 1000L;
-                    log.debug("Pump time difference: " + timeDiff + " seconds");
                 }
                 mDanaRPump.lastSettingsRead = now;
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-﻿<resources>
+<resources>
     <string name="treatmentssafety_title">Treatments safety</string>
     <string name="treatmentssafety_maxbolus_title">Max allowed bolus [U]</string>
     <string name="treatmentssafety_maxcarbs_title">Max allowed carbs [g]</string>
@@ -1172,6 +1172,8 @@
     <string name="combo_invalid_setup">Invalid pump setup, check the docs and verify that the Quick Info menu is named "QUICK INFO" using the 360 configuration software.</string>
     <string name="custom">Custom</string>
     <string name="key_lockscreen" translatable="false">lockscreen</string>
+    <string name="largetimedifftitle">Large Time Difference</string>
+    <string name="largetimediff">Large time difference: Time in pump was adjuted for more than 1.5 hours. Make sure that reading the history from the pump does not cause unexpected behaviour.</string>
 
     <plurals name="objective_days">
         <item quantity="one">%d day</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1175,7 +1175,7 @@
     <string name="custom">Custom</string>
     <string name="key_lockscreen" translatable="false">lockscreen</string>
     <string name="largetimedifftitle">Large Time Difference</string>
-    <string name="largetimediff">Large time difference: Time in pump was adjuted for more than 1.5 hours. Make sure that reading the history from the pump does not cause unexpected behaviour.</string>
+    <string name="largetimediff">Large time difference:\nTime in pump is off by more than 1.5 hours.\nPlease adjust the time manually on the pump and make sure that reading the history from the pump does not cause unexpected behaviour.\nIf possible, remove the history from the pump before changing the time or disable the closed loop for one DIA after the last wrong history entry but minimum one DIA from now.</string>
     <string name="careportal_removestartedevents">Clean AndroidAPS started</string>
 
     <plurals name="objective_days">


### PR DESCRIPTION
Warns when the time is synchronized on Dana RS or Rv2 and the time difference was more than 1.5 hours.

This should not disturb on standard DST changes but at least warns the user.
It would still be good to be able to automatically sync the events (if we could get the info off the pump) or erase the pumps "history" that is wrong (missing the commands?). But at least the user is warned when he travels through time zones.

Thanks @JustinWalkerMDPL for reporting this.