### PR TITLE
Issue 1130 backwards

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/NsClientReceiverDelegate.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/NSClientInternal/NsClientReceiverDelegate.java
@@ -122,7 +122,8 @@ class NsClientReceiverDelegate {
         boolean newAllowedState = true;
 
         if (ev.wifiConnected) {
-            if (!allowedSSIDs.trim().isEmpty() && !allowedSSIDs.contains(ev.getSsid())) {
+            if (!allowedSSIDs.trim().isEmpty() &&
+                    (!allowedSSIDs.contains(ev.getSsid()) && !allowedSSIDs.contains(ev.ssid))) {
                 newAllowedState = false;
             }
         } else {

--- a/app/src/test/java/info/nightscout/androidaps/plugins/NSClientInternal/NsClientReceiverDelegateTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/NSClientInternal/NsClientReceiverDelegateTest.java
@@ -70,6 +70,14 @@ public class NsClientReceiverDelegateTest {
         ev.mobileConnected = true;
         ev.wifiConnected = true;
         assertTrue(sut.calculateStatus(ev));
+
+        ev.ssid = "test";
+        when(SP.getString(anyInt(), anyString())).thenReturn("\"test\"");
+        assertTrue(sut.calculateStatus(ev));
+
+        ev.ssid = "\"test\"";
+        assertTrue(sut.calculateStatus(ev));
+        
         ev.wifiConnected = false;
         assertTrue(sut.calculateStatus(ev));
 


### PR DESCRIPTION
keep backwards compatibility for ssids with quotation marks (not necessary, if documentation is added and all users follow the documtation). Adds testcase for this one as well.