### PR TITLE
For testing: Wear confirm dialog

### DIFF
--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -30,7 +30,7 @@ android {
 
     defaultConfig {
         applicationId "info.nightscout.androidaps"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 23
         versionCode 1
         versionName "1.0.2"
@@ -67,6 +67,7 @@ dependencies {
     implementation "com.google.android.support:wearable:${wearableVersion}"
     implementation "com.google.android.gms:play-services-wearable:7.3.0"
     implementation(name:"ustwo-clockwise-debug", ext:"aar")
-    implementation "com.android.support:support-v4:23.0.1"
+    implementation "com.android.support:support-v4:27.0.1"
+    implementation 'com.android.support:wear:27.0.1'
     implementation "me.denley.wearpreferenceactivity:wearpreferenceactivity:0.5.0"
 }

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
 
     <uses-permission android:name="com.google.android.permission.PROVIDE_BACKGROUND" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.VIBRATE"/>
+
 
     <application
         android:allowBackup="true"

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -205,6 +205,10 @@
             android:label="CPP">
         </activity>
         <activity
+            android:name=".interaction.actions.AcceptActivity"
+            android:label="CPP">
+        </activity>
+        <activity
             android:name=".interaction.actions.FillActivity"
             android:label="Fill">
         </activity>

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -206,7 +206,8 @@
         </activity>
         <activity
             android:name=".interaction.actions.AcceptActivity"
-            android:label="CPP">
+            android:launchMode="singleInstance"
+            android:label="ACCEPT">
         </activity>
         <activity
             android:name=".interaction.actions.FillActivity"

--- a/wear/src/main/java/info/nightscout/androidaps/data/ListenerService.java
+++ b/wear/src/main/java/info/nightscout/androidaps/data/ListenerService.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 import info.nightscout.androidaps.interaction.AAPSPreferences;
 import info.nightscout.androidaps.R;
+import info.nightscout.androidaps.interaction.actions.AcceptActivity;
 import info.nightscout.androidaps.interaction.actions.CPPActivity;
 import info.nightscout.androidaps.interaction.utils.SafeParse;
 
@@ -345,6 +346,16 @@ public class ListenerService extends WearableListenerService implements GoogleAp
 
     private void showConfirmationDialog(String title, String message, String actionstring) {
 
+        Intent intent = new Intent(this, AcceptActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        Bundle params = new Bundle();
+        params.putString("title", title);
+        params.putString("message", message);
+        params.putString("actionstring", actionstring);
+        intent.putExtras(params);
+        startActivity(intent);
+
+        /*
         if(confirmThread != null){
             confirmThread.invalidate();
         }
@@ -375,7 +386,7 @@ public class ListenerService extends WearableListenerService implements GoogleAp
 
         // keep the confirmation dialog open for one minute.
         scheduleDismissConfirm(60);
-
+        */
     }
 
     private void scheduleDismissConfirm(final int seconds) {

--- a/wear/src/main/java/info/nightscout/androidaps/data/ListenerService.java
+++ b/wear/src/main/java/info/nightscout/androidaps/data/ListenerService.java
@@ -354,47 +354,6 @@ public class ListenerService extends WearableListenerService implements GoogleAp
         params.putString("actionstring", actionstring);
         intent.putExtras(params);
         startActivity(intent);
-
-        /*
-        if(confirmThread != null){
-            confirmThread.invalidate();
-        }
-
-        Intent actionIntent = new Intent(this, ListenerService.class);
-        actionIntent.setAction(ACTION_CONFIRMATION);
-        actionIntent.putExtra("actionstring", actionstring);
-        PendingIntent actionPendingIntent = PendingIntent.getService(this, 0, actionIntent, PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_UPDATE_CURRENT);;
-
-        long[] vibratePattern = new long[]{0, 100, 50, 100, 50};
-
-        NotificationCompat.Builder notificationBuilder =
-                new NotificationCompat.Builder(this)
-                        .setSmallIcon(R.drawable.ic_icon)
-                        .setContentTitle(title)
-                        .setContentText(message)
-                        .setContentIntent(actionPendingIntent)
-                        .setPriority(NotificationCompat.PRIORITY_MAX)
-                        .setVibrate(vibratePattern)
-                        .setStyle(new NotificationCompat.BigTextStyle().bigText(message))
-                        .extend(new NotificationCompat.WearableExtender())
-                        .addAction(R.drawable.ic_confirm, title, actionPendingIntent);
-
-        NotificationManagerCompat notificationManager =
-                NotificationManagerCompat.from(this);
-
-        notificationManager.notify(CONFIRM_NOTIF_ID, notificationBuilder.build());
-
-        // keep the confirmation dialog open for one minute.
-        scheduleDismissConfirm(60);
-        */
-    }
-
-    private void scheduleDismissConfirm(final int seconds) {
-        if(confirmThread != null){
-            confirmThread.invalidate();
-        }
-        confirmThread = new DismissThread(CONFIRM_NOTIF_ID, seconds);
-        confirmThread.start();
     }
 
     private void scheduleDismissBolusprogress(final int seconds) {

--- a/wear/src/main/java/info/nightscout/androidaps/data/ListenerService.java
+++ b/wear/src/main/java/info/nightscout/androidaps/data/ListenerService.java
@@ -436,6 +436,13 @@ public class ListenerService extends WearableListenerService implements GoogleAp
         context.startService(intent);
     }
 
+    public static void confirmAction(Context context, String actionstring) {
+        Intent intent = new Intent(context, ListenerService.class);
+        intent.putExtra("actionstring", actionstring);
+        intent.setAction(ACTION_CONFIRMATION);
+        context.startService(intent);
+    }
+
     @Override
     public void onConnected(Bundle bundle) {
         requestData();

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
@@ -1,10 +1,12 @@
 package info.nightscout.androidaps.interaction.actions;
 
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.SystemClock;
+import android.os.Vibrator;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.wearable.view.DotsPageIndicator;
 import android.support.wearable.view.GridPagerAdapter;
@@ -54,6 +56,10 @@ public class AcceptActivity extends ViewSelectorActivity {
         pager.setAdapter(new MyGridViewPagerAdapter());
         DotsPageIndicator dotsPageIndicator = (DotsPageIndicator) findViewById(R.id.page_indicator);
         dotsPageIndicator.setPager(pager);
+
+        Vibrator v = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
+        long[] vibratePattern = new long[]{0, 100, 50, 100, 50};
+        v.vibrate(vibratePattern, -1);
     }
 
 

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
@@ -1,0 +1,111 @@
+package info.nightscout.androidaps.interaction.actions;
+
+
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.wearable.view.DotsPageIndicator;
+import android.support.wearable.view.GridPagerAdapter;
+import android.support.wearable.view.GridViewPager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.text.DecimalFormat;
+
+import info.nightscout.androidaps.R;
+import info.nightscout.androidaps.data.ListenerService;
+import info.nightscout.androidaps.interaction.utils.PlusMinusEditText;
+import info.nightscout.androidaps.interaction.utils.SafeParse;
+
+/**
+ * Created by adrian on 09/02/17.
+ */
+
+
+public class AcceptActivity extends ViewSelectorActivity {
+
+
+    String text = "";
+    String actionstring = "";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Bundle extras = getIntent().getExtras();
+        text = extras.getString("text", "");
+        actionstring = extras.getString("actionstring", "");
+
+        if ("".equals(text) || "".equals(actionstring) ){
+            finish(); return;
+        }
+
+        setContentView(R.layout.grid_layout);
+        final Resources res = getResources();
+        final GridViewPager pager = (GridViewPager) findViewById(R.id.pager);
+
+        pager.setAdapter(new MyGridViewPagerAdapter());
+        DotsPageIndicator dotsPageIndicator = (DotsPageIndicator) findViewById(R.id.page_indicator);
+        dotsPageIndicator.setPager(pager);
+    }
+
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        finish();
+    }
+
+
+    private class MyGridViewPagerAdapter extends GridPagerAdapter {
+        @Override
+        public int getColumnCount(int arg0) {
+            return 2;
+        }
+
+        @Override
+        public int getRowCount() {
+            return 1;
+        }
+
+        @Override
+        public Object instantiateItem(ViewGroup container, int row, int col) {
+
+            if(col == 0){
+                final View view = LayoutInflater.from(getApplicationContext()).inflate(R.layout.action_confirm_text, container, false);
+                final TextView textView = (TextView) view.findViewById(R.id.confirmtext);
+                textView.setText(text);
+                container.addView(view);
+                return view;
+            } else {
+                final View view = LayoutInflater.from(getApplicationContext()).inflate(R.layout.action_send_item, container, false);
+                final ImageView confirmbutton = (ImageView) view.findViewById(R.id.confirmbutton);
+                confirmbutton.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        ListenerService.confirmAction(AcceptActivity.this, actionstring);
+                        finish();
+                    }
+                });
+                container.addView(view);
+                return view;
+            }
+        }
+
+        @Override
+        public void destroyItem(ViewGroup container, int row, int col, Object view) {
+            // Handle this to get the data before the view is destroyed?
+            // Object should still be kept by this, just setup for reinit?
+            container.removeView((View)view);
+        }
+
+        @Override
+        public boolean isViewFromObject(View view, Object object) {
+            return view==object;
+        }
+
+
+    }
+}

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
@@ -3,6 +3,8 @@ package info.nightscout.androidaps.interaction.actions;
 
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.os.SystemClock;
+import android.support.v4.app.NotificationManagerCompat;
 import android.support.wearable.view.DotsPageIndicator;
 import android.support.wearable.view.GridPagerAdapter;
 import android.support.wearable.view.GridViewPager;
@@ -26,10 +28,14 @@ public class AcceptActivity extends ViewSelectorActivity {
     String title = "";
     String message = "";
     String actionstring = "";
+    private DismissThread dismissThread;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        this.dismissThread = new DismissThread();
+        dismissThread.start();
 
         Bundle extras = getIntent().getExtras();
         title = extras.getString("title", "");
@@ -106,6 +112,32 @@ public class AcceptActivity extends ViewSelectorActivity {
             return view==object;
         }
 
+    }
 
+    @Override
+    public synchronized void onDestroy(){
+        super.onDestroy();
+        if(dismissThread != null){
+            dismissThread.invalidate();
+        }
+
+    }
+
+    private class DismissThread extends Thread{
+        private boolean valid = true;
+
+        public synchronized void invalidate(){
+            valid = false;
+        }
+
+        @Override
+        public void run() {
+            SystemClock.sleep(60 * 1000);
+            synchronized (this) {
+                if(valid) {
+                    AcceptActivity.this.finish();
+                }
+            }
+        }
     }
 }

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
@@ -12,12 +12,8 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import java.text.DecimalFormat;
-
 import info.nightscout.androidaps.R;
 import info.nightscout.androidaps.data.ListenerService;
-import info.nightscout.androidaps.interaction.utils.PlusMinusEditText;
-import info.nightscout.androidaps.interaction.utils.SafeParse;
 
 /**
  * Created by adrian on 09/02/17.
@@ -27,7 +23,8 @@ import info.nightscout.androidaps.interaction.utils.SafeParse;
 public class AcceptActivity extends ViewSelectorActivity {
 
 
-    String text = "";
+    String title = "";
+    String message = "";
     String actionstring = "";
 
     @Override
@@ -35,10 +32,11 @@ public class AcceptActivity extends ViewSelectorActivity {
         super.onCreate(savedInstanceState);
 
         Bundle extras = getIntent().getExtras();
-        text = extras.getString("text", "");
+        title = extras.getString("title", "");
+        message = extras.getString("message", "");
         actionstring = extras.getString("actionstring", "");
 
-        if ("".equals(text) || "".equals(actionstring) ){
+        if ("".equals(message) || "".equals(actionstring) ){
             finish(); return;
         }
 
@@ -75,8 +73,10 @@ public class AcceptActivity extends ViewSelectorActivity {
 
             if(col == 0){
                 final View view = LayoutInflater.from(getApplicationContext()).inflate(R.layout.action_confirm_text, container, false);
-                final TextView textView = (TextView) view.findViewById(R.id.confirmtext);
-                textView.setText(text);
+                final TextView headingView = (TextView) view.findViewById(R.id.title);
+                headingView.setText(title);
+                final TextView textView = (TextView) view.findViewById(R.id.message);
+                textView.setText(message);
                 container.addView(view);
                 return view;
             } else {

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
@@ -1,6 +1,7 @@
 package info.nightscout.androidaps.interaction.actions;
 
 
+import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.SystemClock;
@@ -139,5 +140,16 @@ public class AcceptActivity extends ViewSelectorActivity {
                 }
             }
         }
+    }
+
+    @Override
+    protected synchronized void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        if(dismissThread != null) dismissThread.invalidate();
+        Bundle extras = intent.getExtras();
+        Intent msgIntent = new Intent(this, AcceptActivity.class);
+        msgIntent.putExtras(extras);
+        startActivity(msgIntent);
+        finish();
     }
 }

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/menus/MainMenuActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/menus/MainMenuActivity.java
@@ -35,7 +35,7 @@ public class MainMenuActivity extends MenuListActivity {
     protected String[] getElements() {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
-        if(false && !sharedPreferences.getBoolean("wearcontrol", false)){
+        if(!sharedPreferences.getBoolean("wearcontrol", false)){
             return new String[] {
                     "Settings",
                     "Re-Sync"};

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/menus/MainMenuActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/menus/MainMenuActivity.java
@@ -88,16 +88,6 @@ public class MainMenuActivity extends MenuListActivity {
             intent = new Intent(this, FillMenuActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             this.startActivity(intent);
-            /*
-            intent = new Intent(this, AcceptActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            Bundle params = new Bundle();
-            params.putString("heading", "Confirm");
-            params.putString("text", "dies\nist ein\nhoffentlich\n langer text\n\ndies\nist ein\nhoffentlich\n langer text\n\ndies\nist ein\nhoffentlich\n langer text\n\ndies\nist ein\nhoffentlich\n langer text\n\n");
-            params.putString("actionstring", "blablubb");
-            intent.putExtras(params);
-            startActivity(intent);
-            */
         } else if ("eCarb".equals(action)) {
         intent = new Intent(this, ECarbActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/menus/MainMenuActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/menus/MainMenuActivity.java
@@ -85,17 +85,19 @@ public class MainMenuActivity extends MenuListActivity {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             this.startActivity(intent);
         } else if ("Prime/Fill".equals(action)) {
-            /*intent = new Intent(this, FillMenuActivity.class);
+            intent = new Intent(this, FillMenuActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             this.startActivity(intent);
-            */
+            /*
             intent = new Intent(this, AcceptActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             Bundle params = new Bundle();
+            params.putString("heading", "Confirm");
             params.putString("text", "dies\nist ein\nhoffentlich\n langer text\n\ndies\nist ein\nhoffentlich\n langer text\n\ndies\nist ein\nhoffentlich\n langer text\n\ndies\nist ein\nhoffentlich\n langer text\n\n");
             params.putString("actionstring", "blablubb");
             intent.putExtras(params);
             startActivity(intent);
+            */
         } else if ("eCarb".equals(action)) {
         intent = new Intent(this, ECarbActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/menus/MainMenuActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/menus/MainMenuActivity.java
@@ -9,6 +9,7 @@ import java.util.Vector;
 
 import info.nightscout.androidaps.data.ListenerService;
 import info.nightscout.androidaps.interaction.AAPSPreferences;
+import info.nightscout.androidaps.interaction.actions.AcceptActivity;
 import info.nightscout.androidaps.interaction.actions.BolusActivity;
 import info.nightscout.androidaps.interaction.actions.ECarbActivity;
 import info.nightscout.androidaps.interaction.actions.TempTargetActivity;
@@ -34,7 +35,7 @@ public class MainMenuActivity extends MenuListActivity {
     protected String[] getElements() {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
-        if(!sharedPreferences.getBoolean("wearcontrol", false)){
+        if(false && !sharedPreferences.getBoolean("wearcontrol", false)){
             return new String[] {
                     "Settings",
                     "Re-Sync"};
@@ -84,9 +85,17 @@ public class MainMenuActivity extends MenuListActivity {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             this.startActivity(intent);
         } else if ("Prime/Fill".equals(action)) {
-            intent = new Intent(this, FillMenuActivity.class);
+            /*intent = new Intent(this, FillMenuActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             this.startActivity(intent);
+            */
+            intent = new Intent(this, AcceptActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            Bundle params = new Bundle();
+            params.putString("text", "dies\nist ein\nhoffentlich\n langer text\n\ndies\nist ein\nhoffentlich\n langer text\n\ndies\nist ein\nhoffentlich\n langer text\n\ndies\nist ein\nhoffentlich\n langer text\n\n");
+            params.putString("actionstring", "blablubb");
+            intent.putExtras(params);
+            startActivity(intent);
         } else if ("eCarb".equals(action)) {
         intent = new Intent(this, ECarbActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/wear/src/main/res/layout/action_confirm_text.xml
+++ b/wear/src/main/res/layout/action_confirm_text.xml
@@ -14,12 +14,25 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <TextView
-                android:id="@+id/confirmtext"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:text="asdfas"
-                android:textColor="@color/white" />
+                android:orientation="vertical">
+                <TextView
+                    android:id="@+id/title"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:text="title"
+                    android:textAppearance="@style/TextAppearance.Wearable.Large"
+                    android:textColor="@color/white" />
+                <TextView
+                    android:id="@+id/message"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:text="message"
+                    android:textAppearance="@style/TextAppearance.Wearable.Medium"
+                    android:textColor="@color/white" />
+            </LinearLayout>
 
         </android.support.v4.widget.NestedScrollView>
 

--- a/wear/src/main/res/layout/action_confirm_text.xml
+++ b/wear/src/main/res/layout/action_confirm_text.xml
@@ -1,0 +1,27 @@
+<android.support.wear.widget.BoxInsetLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="15dp">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="5dp"
+        app:boxedEdges="all">
+
+        <android.support.v4.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/confirmtext"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:text="asdfas"
+                android:textColor="@color/white" />
+
+        </android.support.v4.widget.NestedScrollView>
+
+    </FrameLayout>
+</android.support.wear.widget.BoxInsetLayout>

--- a/wear/src/main/res/layout/action_confirm_text.xml
+++ b/wear/src/main/res/layout/action_confirm_text.xml
@@ -23,14 +23,14 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:text="title"
-                    android:textAppearance="@style/TextAppearance.Wearable.Large"
+                    android:textAppearance="@style/TextAppearance.Wearable.Medium"
                     android:textColor="@color/white" />
                 <TextView
                     android:id="@+id/message"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:text="message"
-                    android:textAppearance="@style/TextAppearance.Wearable.Medium"
+                    android:textAppearance="@style/TextAppearance.Wearable.Small"
                     android:textColor="@color/white" />
             </LinearLayout>
 


### PR DESCRIPTION
@jotomo, @blocklist.de and @gregorybel, could you please test this on a wear 2.0 watch?
It should now have the confirm dialog not as a notification but as an activity with scrolable text.
This should solve the problem that a simple tap can confirm a bolus.

Is the text too large (On my Sony Smartwatch 3 it is rather large but still ok)?