### PR TITLE
For review: Don't post an EventNewBg when updating a record.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
@@ -350,7 +350,6 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
                 old.copyFrom(bgReading);
                 getDaoBgReadings().update(old);
                 log.debug("BG: Updating record from: " + from + " New data: " + old.toString());
-                scheduleBgChange(bgReading);
                 return false;
             }
         } catch (SQLException e) {


### PR DESCRIPTION
Doesn't break backfilling, but prevents geniune new BG readings
from being kicked in DatabaseHelper.scheduleBgChange when an
updated BG arrives.
Updates are done to add the _id field from Nightscout.