### PR TITLE
For review: Last 2.0 something stuff update1

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/Treatment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/Treatment.java
@@ -169,6 +169,7 @@ public class Treatment implements DataPointWithLabelInterface {
         insulin = t.insulin;
         carbs = t.carbs;
         pumpId = t.pumpId;
+        source = t.source;
     }
 
     //  ----------------- DataPointInterface --------------------


### PR DESCRIPTION
@MilosKozak  This is only in illustration of an idea for a workaround:

Alarm if a treatment that has NOT pump as source exists and update it with the treatment that has pump as source.

Don't alarm If a pump-record overwrites itself (e.g after an occlusion alarm a newer record with updated insulin comes in).