### PR TITLE
Idea: Fabric-log used openaps version upon invocation.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/MainApp.java
+++ b/app/src/main/java/info/nightscout/androidaps/MainApp.java
@@ -196,16 +196,18 @@ public class MainApp extends Application {
         }
         NSUpload.uploadAppStart();
 
-        if (Config.NSCLIENT)
+        if (Config.NSCLIENT) {
             FabricPrivacy.getInstance().logCustom(new CustomEvent("AppStart-NSClient"));
-        else if (Config.G5UPLOADER)
+        } else if (Config.G5UPLOADER) {
             FabricPrivacy.getInstance().logCustom(new CustomEvent("AppStart-G5Uploader"));
-        else if (Config.PUMPCONTROL)
+        } else if (Config.PUMPCONTROL) {
             FabricPrivacy.getInstance().logCustom(new CustomEvent("AppStart-PumpControl"));
-        else if (MainApp.getConstraintChecker().isClosedLoopAllowed().value())
+        } else if (MainApp.getConstraintChecker().isClosedLoopAllowed().value()) {
             FabricPrivacy.getInstance().logCustom(new CustomEvent("AppStart-ClosedLoop"));
-        else
+            uploadPluginStats();
+        } else {
             FabricPrivacy.getInstance().logCustom(new CustomEvent("AppStart-OpenLoop"));
+        }
 
         final PumpInterface pump = ConfigBuilderPlugin.getActivePump();
         if (pump != null) {
@@ -215,6 +217,14 @@ public class MainApp extends Application {
                 startKeepAliveService();
             }).start();
         }
+    }
+
+    private void uploadPluginStats() {
+        CustomEvent pluginStats = new CustomEvent("PluginStats");
+        for (PluginBase pluginBase : pluginsList) {
+            pluginStats.putCustomAttribute(pluginBase.getName(), pluginBase.isEnabled(pluginBase.getType()) ? "enabled" : "disabled");
+        }
+        FabricPrivacy.getInstance().logCustom(pluginStats);
     }
 
     private void registerLocalBroadcastReceiver() {

--- a/app/src/main/java/info/nightscout/androidaps/interfaces/APSInterface.java
+++ b/app/src/main/java/info/nightscout/androidaps/interfaces/APSInterface.java
@@ -12,4 +12,6 @@ public interface APSInterface {
     public Date getLastAPSRun();
 
     public void invoke(String initiator, boolean tempBasalFallback);
+
+    String getVersion();
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
@@ -343,7 +343,8 @@ public class LoopPlugin extends PluginBase {
                     if (resultAfterConstraints.bolusRequested)
                         lastRun.smbSetByPump = waiting;
                     MainApp.bus().post(new EventLoopUpdateGui());
-                    FabricPrivacy.getInstance().logCustom(new CustomEvent("APSRequest"));
+                    FabricPrivacy.getInstance().logCustom(new CustomEvent("APSRequest")
+                            .putCustomAttribute("openapsVersion", ConfigBuilderPlugin.getActiveAPS().toString()));
                     MainApp.getConfigBuilder().applyTBRRequest(resultAfterConstraints, profile, new Callback() {
                         @Override
                         public void run() {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/OpenAPSAMAPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSAMA/OpenAPSAMAPlugin.java
@@ -227,4 +227,9 @@ public class OpenAPSAMAPlugin extends PluginBase implements APSInterface {
         //deviceStatus.suggested = determineBasalResultAMA.json;
     }
 
+    @Override
+    public String getVersion() {
+        return "oref0 AMA";
+    }
+
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSMA/OpenAPSMAPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSMA/OpenAPSMAPlugin.java
@@ -211,5 +211,10 @@ public class OpenAPSMAPlugin extends PluginBase implements APSInterface {
         MainApp.bus().post(new EventOpenAPSUpdateGui());
     }
 
+    @Override
+    public String getVersion() {
+        return "oref0 MA";
+    }
+
 
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/OpenAPSSMBPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/OpenAPSSMBPlugin.java
@@ -246,6 +246,11 @@ public class OpenAPSSMBPlugin extends PluginBase implements APSInterface {
         //deviceStatus.suggested = determineBasalResultAMA.json;
     }
 
+    @Override
+    public String getVersion() {
+        return "oref1 0.6.0";
+    }
+
     // safety checks
     private static boolean checkOnlyHardLimits(Double value, String valueName, double lowLimit, double highLimit) {
         return value.equals(verifyHardLimits(value, valueName, lowLimit, highLimit));

--- a/app/src/test/java/info/nightscout/androidaps/interfaces/ConstraintsCheckerTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/interfaces/ConstraintsCheckerTest.java
@@ -233,13 +233,14 @@ public class ConstraintsCheckerTest {
         // No limit by default
         when(SP.getDouble(R.string.key_openapsma_max_iob, 1.5d)).thenReturn(1.5d);
         when(SP.getString(R.string.key_age, "")).thenReturn("teenage");
-        OpenAPSMAPlugin.getPlugin().setPluginEnabled(PluginType.APS, true);
         OpenAPSAMAPlugin.getPlugin().setPluginEnabled(PluginType.APS, true);
+        OpenAPSMAPlugin.getPlugin().setPluginEnabled(PluginType.APS, false);
+        OpenAPSSMBPlugin.getPlugin().setPluginEnabled(PluginType.APS, false);
 
         // Apply all limits
         Constraint<Double> d = constraintChecker.getMaxIOBAllowed();
         Assert.assertEquals(1.5d, d.value());
-        Assert.assertEquals(3, d.getReasonList().size());
+        Assert.assertEquals(d.getReasonList().toString(),2, d.getReasonList().size());
         Assert.assertEquals("Safety: Limiting IOB to 1.5 U because of max value in preferences", d.getMostLimitedReasons());
 
     }
@@ -250,11 +251,13 @@ public class ConstraintsCheckerTest {
         when(SP.getDouble(R.string.key_openapssmb_max_iob, 3d)).thenReturn(3d);
         when(SP.getString(R.string.key_age, "")).thenReturn("teenage");
         OpenAPSSMBPlugin.getPlugin().setPluginEnabled(PluginType.APS, true);
+        OpenAPSAMAPlugin.getPlugin().setPluginEnabled(PluginType.APS, false);
+        OpenAPSMAPlugin.getPlugin().setPluginEnabled(PluginType.APS, false);
 
         // Apply all limits
         Constraint<Double> d = constraintChecker.getMaxIOBAllowed();
         Assert.assertEquals(3d, d.value());
-        Assert.assertEquals(4, d.getReasonList().size());
+        Assert.assertEquals(d.getReasonList().toString(), 2, d.getReasonList().size());
         Assert.assertEquals("Safety: Limiting IOB to 3.0 U because of max value in preferences", d.getMostLimitedReasons());
 
     }


### PR DESCRIPTION
To get an idea when older plugins can be sensibly removed.