### PR TITLE
Disable history browser unless on dev-branch.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/MainActivity.java
+++ b/app/src/main/java/info/nightscout/androidaps/MainActivity.java
@@ -344,6 +344,7 @@ public class MainActivity extends AppCompatActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_main, menu);
         pluginPreferencesMenuItem = menu.findItem(R.id.nav_plugin_preferences);
+        menu.findItem(R.id.nav_historybrowser).setVisible(MainApp.devBranch);
         checkPluginPreferences(findViewById(R.id.pager));
         return true;
     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/Actions/ActionsFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Actions/ActionsFragment.java
@@ -87,6 +87,7 @@ public class ActionsFragment extends SubscriberFragment implements View.OnClickL
             tempBasalCancel.setOnClickListener(this);
             fill.setOnClickListener(this);
             history.setOnClickListener(this);
+            history.setVisibility(MainApp.devBranch ? View.VISIBLE : View.GONE);
             tddStats.setOnClickListener(this);
 
             updateGUI();


### PR DESCRIPTION
If history browser is part of a release, users will expect it to be fully working. Since the history browser isn't there yet, I think it should be restricted to the `dev` branch until it's further along to avoid bug reports about missing functionality.