### PR TITLE
eCarbs delay->start

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1174,7 +1174,7 @@
     <string name="delete_logs">Delete Logs</string>
 
     <string name="error_adding_treatment_message">A treatment (insulin: %1$.2f, carbs: %2$d, at: %3$s) could not be added to treatments. Please check and manually add a record as appropriate.</string>
-    <string name="generated_ecarbs_note">eCarbs: %1$d g (%2$d h), delay: %3$d m</string>
+    <string name="generated_ecarbs_note">eCarbs: %1$d g (%2$d h), start: %3$d m</string>
     <string name="key_plugin_stats_report_timestamp" translatable="false">key_plugin_stats_report_timestamp</string>
     <string name="openaps_noasdata">No autosens data available</string>
     <string name="nav_logsettings">Log settings</string>


### PR DESCRIPTION
To avoid the confusion between the period of time the carbs are spread and the delay when it starts.