### PR TITLE
[Regression] Only log about records with duplicate pump id.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/TreatmentService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Treatments/TreatmentService.java
@@ -381,16 +381,14 @@ public class TreatmentService extends OrmLiteBaseService<DatabaseHelper> {
             QueryBuilder<Treatment, Long> queryBuilder = getDao().queryBuilder();
             Where where = queryBuilder.where();
             where.eq("pumpId", pumpId);
-            PreparedQuery<Treatment> preparedQuery = queryBuilder.prepare();
-            List<Treatment> result = getDao().query(preparedQuery);
-            switch (result.size()) {
-                case 0:
-                    return null;
-                case 1:
-                    return result.get(0);
-                default:
-                    throw new RuntimeException("Multiple records with the same pump id found: " + result.toString());
-            }
+            queryBuilder.orderBy("date", true);
+
+            List<Treatment> result = getDao().query(queryBuilder.prepare());
+            if (result.isEmpty())
+                return null;
+            if (result.size() > 1)
+                log.warn("Multiple records with the same pump id found (returning first one): " + result.toString());
+            return result.get(0);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This undoes a behavioral change (introduced via f12db81f96e9c3764b2e684ed3f83241ff611e2f), which throws an exception if there are multiple records with the same pump id. This was ignored before and this patch restores that behavior and simply logs about the issue.
Such a state may or may not be legal, however this seems to be most reasonable way to deal with this at this point, given the current data model, while giving the user the chance to recover, otherwise the app will just crash.