### PR TITLE
Notifications about tbr suggestions. Fixes #1318

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
@@ -399,8 +399,10 @@ public class LoopPlugin extends PluginBase {
                             .setAutoCancel(true)
                             .setPriority(Notification.PRIORITY_HIGH)
                             .setCategory(Notification.CATEGORY_ALARM)
-                            .setVisibility(Notification.VISIBILITY_PUBLIC)
-                            .setLocalOnly(true);
+                            .setVisibility(Notification.VISIBILITY_PUBLIC);
+                    if (SP.getBoolean("wearcontrol", false)) {
+                        builder.setLocalOnly(true);
+                    }
 
                     // Creates an explicit intent for an Activity in your app
                     Intent resultIntent = new Intent(MainApp.instance().getApplicationContext(), MainActivity.class);


### PR DESCRIPTION
This PR should fix #1318.

If ControlsFromWear is On, the Notifications will be set locally and therefore won't get mirrored on the watch.

Should this check also be performed for the ActionStringHandler calls?