### PR TITLE
Assume md/dl units for temp targets created through Nightscout

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import info.nightscout.androidaps.Constants;
 import info.nightscout.androidaps.MainApp;
 import info.nightscout.androidaps.data.OverlappingIntervals;
 import info.nightscout.androidaps.data.Profile;
@@ -698,7 +699,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
 
     public void createTemptargetFromJsonIfNotExists(JSONObject trJson) {
         try {
-            String units = JsonHelper.safeGetString(trJson, "units", ProfileFunctions.getInstance().getProfileUnits());
+            String units = JsonHelper.safeGetString(trJson, "units", Constants.MGDL);
             TempTarget tempTarget = new TempTarget()
                     .date(trJson.getLong("mills"))
                     .duration(trJson.getInt("duration"))


### PR DESCRIPTION
Not sure if this is a general problem, but if I create a temp target in Nightscout (v 0.10.3) the `units` field is not populated. Although I enter the target in mmol, Nightscout seems to convert it to mg/dl. When this is received by AAPS, because the units aren't set explicitly in the JSON and my profile is in mmol, the target gets converted again and ends up being 18 times greater than expected, which in turn starts triggering warnings about the value being out of range.