### PR TITLE
update other "G5 Native" source reference for G6

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Source/SourceNSClientPlugin.java
@@ -99,7 +99,7 @@ public class SourceNSClientPlugin extends PluginBase implements BgSourceInterfac
 
     public void detectSource(String source, long timeStamp) {
         if (timeStamp > lastBGTimeStamp) {
-            if (source.contains("G5 Native") || source.contains("AndroidAPS-DexcomG5"))
+            if (source.contains("G5 Native") || source.contains("G6 Native") || source.contains("AndroidAPS-DexcomG5"))
                 isAdvancedFilteringEnabled = true;
             else
                 isAdvancedFilteringEnabled = false;


### PR DESCRIPTION
I think this change should be needed to stay internally consistent with https://github.com/MilosKozak/AndroidAPS/pull/1361