### PR TITLE
Use profilename of currently active profile. Fixes #1425.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Overview/Dialogs/WizardDialog.java
@@ -480,7 +480,7 @@ public class WizardDialog extends DialogFragment implements OnClickListener, Com
         Profile specificProfile;
         if (selectedAlternativeProfile.equals(MainApp.gs(R.string.active))) {
             specificProfile = ProfileFunctions.getInstance().getProfile();
-            selectedAlternativeProfile = MainApp.getConfigBuilder().getActiveProfileInterface().getProfileName();
+            selectedAlternativeProfile = ProfileFunctions.getInstance().getProfileName();
         } else
             specificProfile = profileStore.getSpecificProfile(selectedAlternativeProfile);
 


### PR DESCRIPTION
Use the profile name of the currently active profile (determined via ProfileFunctions) in the wizard. This PR fixes #1425.

Before the name of the default profile in the profilestore received from NS was used.