### PR TITLE
Update PumpType.java - fixes issue that zero temps cannot be enacted when very small basals are running

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpCommon/defs/PumpType.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpCommon/defs/PumpType.java
@@ -38,7 +38,7 @@ public enum PumpType {
             new DoseSettings(0.1d, 15, 12*60, 0.1d), //
             PumpTempBasalType.Percent,
             new DoseSettings(10,  15, 12*60,0d, 500d), PumpCapability.BasalRate_Duration15and30minAllowed, //
-            0.01d, 0.1d, DoseStepSize.ComboBasal, PumpCapability.ComboCapabilities), //
+            0.01d, 0.01d, DoseStepSize.ComboBasal, PumpCapability.ComboCapabilities), //
 
     AccuChekSpirit("Accu-Chek Spirit", 0.1d, null, //
             new DoseSettings(0.1d, 15, 12*60, 0.1d), //
@@ -50,7 +50,7 @@ public enum PumpType {
             new DoseSettings(0.05d, 15, 24*60, 0.05d), //
             PumpTempBasalType.Percent,
             new DoseSettings(10,  15, 12*60,0d, 250d), PumpCapability.BasalRate_Duration15and30minAllowed, //
-            0.02d, 0.1d, null, PumpCapability.InsightCapabilities), //
+            0.02d, 0.01d, null, PumpCapability.InsightCapabilities), //
 
     // Animas
     AnimasVibe("Animas Vibe", 0.05d, null, // AnimasBolus?


### PR DESCRIPTION
Ammended the basebasalstep values for the insight and the combo.

This was preventing AAPS from implementing zero basals (or other small basals) where the basalstep value was higher than the current running basal rate 

e.g. basal of 0.06u\hr running and a basalstep 0f 0.1u\hr resulted in no zero temp being enacted because of logic in the loopplugin: Math.abs(request.rate - activeTemp.tempBasalConvertedToAbsolute(now, profile)) < pump.getPumpDescription().basalStep)

this will be affecting other pumps so we probably need to implement warning messages where the baselstep is higher than the basalrate, or change the way we implement zero temps.