### PR TITLE
Fix TBR maximum for Animas Vibe

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpCommon/defs/PumpType.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpCommon/defs/PumpType.java
@@ -56,7 +56,7 @@ public enum PumpType {
     AnimasVibe("Animas Vibe", 0.05d, null, // AnimasBolus?
             new DoseSettings(0.05d, 30, 12*60, 0.05d), //
             PumpTempBasalType.Percent, //
-            new DoseSettings(10, 30, 24*60, 0d, 200d), PumpCapability.BasalRate_Duration30minAllowed, //
+            new DoseSettings(10, 30, 24*60, 0d, 300d), PumpCapability.BasalRate_Duration30minAllowed, //
             0.025d, 5d, 0d, null, PumpCapability.VirtualPumpCapabilities), //
 
     AnimasPing("Animas Ping", AnimasVibe),


### PR DESCRIPTION
Animas Vibe actually supports 300% TBR, but uses a different way of
displaying it:

* 0% is the same as 100% in AAPS.
* -100% (OFF) is 0% in AAPS
* 200% therefore is 300% in AAPS.

Maybe there should be a better indicator for this in AAPS, but for now
this fix gives better control of the TBR values, if using the open loop.