### PR TITLE
Simplify SWItem.generateLayout()

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/setupwizard/elements/SWItem.java
+++ b/app/src/main/java/info/nightscout/androidaps/setupwizard/elements/SWItem.java
@@ -81,7 +81,7 @@ public class SWItem {
     }
 
     public static LinearLayout generateLayout(View view) {
-        LinearLayout layout = (LinearLayout) view.findViewById(view.getId());
+        LinearLayout layout = (LinearLayout) view;
         layout.removeAllViews();
         return layout;
     }


### PR DESCRIPTION
I think the call of ``findViewById`` is redundant at this point.