### PR TITLE
Combo: allow records created by the combo to be merged with existing records.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpCombo/ComboPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpCombo/ComboPlugin.java
@@ -665,15 +665,7 @@ public class ComboPlugin extends PluginBase implements PumpInterface, Constraint
         dbi.source = Source.PUMP;
         dbi.insulin = lastPumpBolus.amount;
         try {
-            boolean treatmentCreated = TreatmentsPlugin.getPlugin().addToHistoryTreatment(dbi, false);
-            if (!treatmentCreated) {
-                log.error("Adding treatment record overrode an existing record: " + dbi);
-                if (dbi.isSMB) {
-                    Notification notification = new Notification(Notification.COMBO_PUMP_ALARM, MainApp.gs(R.string.combo_error_updating_treatment_record), Notification.URGENT);
-                    MainApp.bus().post(new EventNewNotification(notification));
-                }
-                return false;
-            }
+            TreatmentsPlugin.getPlugin().addToHistoryTreatment(dbi, true);
         } catch (Exception e) {
             log.error("Adding treatment record failed", e);
             if (dbi.isSMB) {
@@ -1158,8 +1150,7 @@ public class ComboPlugin extends PluginBase implements PumpInterface, Constraint
             dbi.source = Source.PUMP;
             dbi.insulin = pumpBolus.amount;
             dbi.eventType = CareportalEvent.CORRECTIONBOLUS;
-            if (TreatmentsPlugin.getPlugin().getService().getPumpRecordById(dbi.pumpId) == null) {
-                TreatmentsPlugin.getPlugin().addToHistoryTreatment(dbi, false);
+            if (TreatmentsPlugin.getPlugin().addToHistoryTreatment(dbi, true)) {
                 updated = true;
             }
         }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpCombo/ComboPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpCombo/ComboPlugin.java
@@ -653,11 +653,7 @@ public class ComboPlugin extends PluginBase implements PumpInterface, Constraint
         }
     }
 
-    /**
-     * Updates a DetailedBolusInfo from a pump bolus and adds it as a Treatment to the DB.
-     * Handles edge cases when dates aren't unique which are extremely unlikely to occur,
-     * but if they do, the user should be warned since a bolus will be missing from calculations.
-     */
+    /** Creates a treatment record based on the request in DetailBolusInfo and the delivered bolus. */
     private boolean addBolusToTreatments(DetailedBolusInfo detailedBolusInfo, Bolus lastPumpBolus) {
         DetailedBolusInfo dbi = detailedBolusInfo.copy();
         dbi.date = calculateFakeBolusDate(lastPumpBolus);
@@ -1141,6 +1137,7 @@ public class ComboPlugin extends PluginBase implements PumpInterface, Constraint
         return historyResult.success;
     }
 
+    /** Return value indicates whether a new record was created. */
     private boolean updateDbFromPumpHistory(@NonNull PumpHistory history) {
         boolean updated = false;
         for (Bolus pumpBolus : history.bolusHistory) {


### PR DESCRIPTION
So far, the Combo driver operated under the assumption that pump records where only ever created by a pump and that records are immutable. Therefore, creating a record that collided with an existing record was an error situation. 

Now that treatments are merged together from NS, carb entries and pump records (and hacks to work around clashes of timestamp ids within the same second), this holds now longer true. The error messages observed have all been false positives and where confined to the Combo. 

This PR changes the Combo driver to not insist on unique records, but lets the _TreatmentsPlugin.getPlugin().addToHistoryTreatment_ method take whatever action is suitable to create or update the DB.

Since I don't have a setup that can reproduce this, this needs to be tested:
1) normal boluses should still be added properly (shouldn't be an issue)
2) bolusing from the pump and immediately after giving a bolus from AAPS should be rejected, stating that the bolus was calculation based on outdated data
3) and of course during pump init the bogus error messages should be gone.

How to test: go to menu _VCS->Git->Remotes..._, add a new remote with name _jotomo_ and URL `git@github.com:jotomo/AndroidAPS.git`. Then, _VCS->Git->Fetch_, followed by _VCS->Git->Branches_ and checkout branch _jotomo/upstream-11482+1489_. Build and deploy as normal.

Initial assessment: https://github.com/MilosKozak/AndroidAPS/issues/1482#issuecomment-427333965