### PR TITLE
UAMSMBBasal Minutes and Min SMB dosage

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
@@ -25,6 +25,7 @@ import info.nightscout.androidaps.data.IobTotal;
 import info.nightscout.androidaps.data.MealData;
 import info.nightscout.androidaps.data.Profile;
 import info.nightscout.androidaps.db.TemporaryBasal;
+import info.nightscout.androidaps.interfaces.PumpInterface;
 import info.nightscout.androidaps.logging.L;
 import info.nightscout.androidaps.plugins.IobCobCalculator.IobCobCalculatorPlugin;
 import info.nightscout.androidaps.plugins.Loop.ScriptReader;
@@ -215,7 +216,8 @@ public class DetermineBasalAdapterSMBJS {
     ) throws JSONException {
 
         String units = profile.getUnits();
-
+        Double bolusincrument = SP.getDouble("key_bolus_increment", SMBDefaults.bolus_increment);
+        Double pumpbolusstep = MainApp.getConfigBuilder().getActivePump().getPumpDescription().bolusStep;
         mProfile = new JSONObject();
 
         mProfile.put("max_iob", maxIob);
@@ -256,7 +258,11 @@ public class DetermineBasalAdapterSMBJS {
         mProfile.put("enableSMB_after_carbs", SP.getBoolean(R.string.key_enableSMB_after_carbs, false) && advancedFiltering);
         mProfile.put("maxSMBBasalMinutes", SP.getInt("key_smbmaxminutes", SMBDefaults.maxSMBBasalMinutes));
         mProfile.put("maxUAMSMBBasalMinutes", SP.getInt("key_uamsmbmaxminutes", SMBDefaults.maxUAMSMBBasalMinutes));
-        mProfile.put("bolus_increment", SP.getDouble("key_bolus_increment", SMBDefaults.bolus_increment));
+        if (bolusincrument < pumpbolusstep){
+          //the bolus incrument is less than what the pump can support (by pump settings or pump restriction), set to value supported by the pump
+          bolusincrument = pumpbolusstep;
+        }
+        mProfile.put("bolus_increment", bolusincrument);
         mProfile.put("carbsReqThreshold", SMBDefaults.carbsReqThreshold);
 
         mProfile.put("current_basal", basalrate);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
@@ -256,7 +256,7 @@ public class DetermineBasalAdapterSMBJS {
         mProfile.put("enableSMB_after_carbs", SP.getBoolean(R.string.key_enableSMB_after_carbs, false) && advancedFiltering);
         mProfile.put("maxSMBBasalMinutes", SP.getInt("key_smbmaxminutes", SMBDefaults.maxSMBBasalMinutes));
         mProfile.put("maxUAMSMBBasalMinutes", SP.getInt("key_uamsmbmaxminutes", SMBDefaults.maxUAMSMBBasalMinutes));
-        mProfile.put("bolus_increment", SP.getDouble("bolus_increment", SMBDefaults.bolus_increment));
+        mProfile.put("bolus_increment", SP.getDouble("key_bolus_increment", SMBDefaults.bolus_increment));
         mProfile.put("carbsReqThreshold", SMBDefaults.carbsReqThreshold);
 
         mProfile.put("current_basal", basalrate);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
@@ -27,6 +27,7 @@ import info.nightscout.androidaps.data.Profile;
 import info.nightscout.androidaps.db.TemporaryBasal;
 import info.nightscout.androidaps.interfaces.PumpInterface;
 import info.nightscout.androidaps.logging.L;
+import info.nightscout.androidaps.plugins.ConfigBuilder.ConfigBuilderPlugin;
 import info.nightscout.androidaps.plugins.IobCobCalculator.IobCobCalculatorPlugin;
 import info.nightscout.androidaps.plugins.Loop.ScriptReader;
 import info.nightscout.androidaps.plugins.OpenAPSMA.LoggerCallback;
@@ -217,7 +218,7 @@ public class DetermineBasalAdapterSMBJS {
 
         String units = profile.getUnits();
         Double bolusincrument = SP.getDouble("key_bolus_increment", SMBDefaults.bolus_increment);
-        Double pumpbolusstep = MainApp.getConfigBuilder().getActivePump().getPumpDescription().bolusStep;
+        Double pumpbolusstep = ConfigBuilderPlugin.getPlugin().getActivePump().getPumpDescription().bolusStep;
         mProfile = new JSONObject();
 
         mProfile.put("max_iob", maxIob);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
@@ -44,7 +44,6 @@ public class DetermineBasalAdapterSMBJS {
     private JSONObject mMealData;
     private JSONObject mCurrentTemp;
     private JSONObject mAutosensData = null;
-    private long mCurrentTime;
     private boolean mMicrobolusAllowed;
     private boolean mSMBAlwaysAllowed;
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
@@ -257,7 +257,7 @@ public class DetermineBasalAdapterSMBJS {
         mProfile.put("enableSMB_after_carbs", SP.getBoolean(R.string.key_enableSMB_after_carbs, false) && advancedFiltering);
         mProfile.put("maxSMBBasalMinutes", SP.getInt("key_smbmaxminutes", SMBDefaults.maxSMBBasalMinutes));
         mProfile.put("maxUAMSMBBasalMinutes", SP.getInt("key_uamsmbmaxminutes", SMBDefaults.maxUAMSMBBasalMinutes));
-        mProfile.put("bolus_increment", SP.getDouble("key_bolus_increment", SMBDefaults.bolus_increment));
+        mProfile.put("bolus_increment", SP.getDouble("bolus_increment", SMBDefaults.bolus_increment));
         mProfile.put("carbsReqThreshold", SMBDefaults.carbsReqThreshold);
 
         mProfile.put("current_basal", basalrate);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
@@ -44,6 +44,7 @@ public class DetermineBasalAdapterSMBJS {
     private JSONObject mMealData;
     private JSONObject mCurrentTemp;
     private JSONObject mAutosensData = null;
+    private long mCurrentTime;
     private boolean mMicrobolusAllowed;
     private boolean mSMBAlwaysAllowed;
 
@@ -255,6 +256,8 @@ public class DetermineBasalAdapterSMBJS {
         mProfile.put("enableSMB_always", SP.getBoolean(R.string.key_enableSMB_always, false) && advancedFiltering);
         mProfile.put("enableSMB_after_carbs", SP.getBoolean(R.string.key_enableSMB_after_carbs, false) && advancedFiltering);
         mProfile.put("maxSMBBasalMinutes", SP.getInt("key_smbmaxminutes", SMBDefaults.maxSMBBasalMinutes));
+        mProfile.put("maxUAMSMBBasalMinutes", SP.getInt("key_uamsmbmaxminutes", SMBDefaults.maxUAMSMBBasalMinutes));
+        mProfile.put("bolus_increment", SMBDefaults.bolus_increment);
         mProfile.put("carbsReqThreshold", SMBDefaults.carbsReqThreshold);
 
         mProfile.put("current_basal", basalrate);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
@@ -217,7 +217,7 @@ public class DetermineBasalAdapterSMBJS {
     ) throws JSONException {
 
         String units = profile.getUnits();
-        Double bolusincrument = SP.getDouble("key_bolus_increment", SMBDefaults.bolus_increment);
+        Double bolusincrement = SP.getDouble("key_bolus_increment", SMBDefaults.bolus_increment);
         Double pumpbolusstep = ConfigBuilderPlugin.getPlugin().getActivePump().getPumpDescription().bolusStep;
         mProfile = new JSONObject();
 
@@ -259,11 +259,11 @@ public class DetermineBasalAdapterSMBJS {
         mProfile.put("enableSMB_after_carbs", SP.getBoolean(R.string.key_enableSMB_after_carbs, false) && advancedFiltering);
         mProfile.put("maxSMBBasalMinutes", SP.getInt("key_smbmaxminutes", SMBDefaults.maxSMBBasalMinutes));
         mProfile.put("maxUAMSMBBasalMinutes", SP.getInt("key_uamsmbmaxminutes", SMBDefaults.maxUAMSMBBasalMinutes));
-        if (bolusincrument < pumpbolusstep){
+        if (bolusincrement < pumpbolusstep){
           //the bolus incrument is less than what the pump can support (by pump settings or pump restriction), set to value supported by the pump
-          bolusincrument = pumpbolusstep;
+          bolusincrement = pumpbolusstep;
         }
-        mProfile.put("bolus_increment", bolusincrument);
+        mProfile.put("bolus_increment", bolusincrement);
         mProfile.put("carbsReqThreshold", SMBDefaults.carbsReqThreshold);
 
         mProfile.put("current_basal", basalrate);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
@@ -257,7 +257,7 @@ public class DetermineBasalAdapterSMBJS {
         mProfile.put("enableSMB_after_carbs", SP.getBoolean(R.string.key_enableSMB_after_carbs, false) && advancedFiltering);
         mProfile.put("maxSMBBasalMinutes", SP.getInt("key_smbmaxminutes", SMBDefaults.maxSMBBasalMinutes));
         mProfile.put("maxUAMSMBBasalMinutes", SP.getInt("key_uamsmbmaxminutes", SMBDefaults.maxUAMSMBBasalMinutes));
-        mProfile.put("bolus_increment", SMBDefaults.bolus_increment);
+        mProfile.put("bolus_increment", SP.getDouble("key_bolus_increment", SMBDefaults.bolus_increment));
         mProfile.put("carbsReqThreshold", SMBDefaults.carbsReqThreshold);
 
         mProfile.put("current_basal", basalrate);

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/SMBDefaults.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/SMBDefaults.java
@@ -56,9 +56,11 @@ public class SMBDefaults {
     //public final static boolean enableSMB_after_carbs = false; // enable supermicrobolus for 6h after carbs, even with 0 COB
     //public final static boolean allowSMB_with_high_temptarget = false; // allow supermicrobolus (if otherwise enabled) even with high temp targets
     public final static int maxSMBBasalMinutes = 30; // maximum minutes of basal that can be delivered as a single SMB with uncovered COB
+    public final static int maxUAMSMBBasalMinutes = 30; // maximum minutes of basal that can be delivered as a single SMB when IOB exceeds COB
     // curve:"rapid-acting" // Supported curves: "bilinear", "rapid-acting" (Novolog, Novorapid, Humalog, Apidra) and "ultra-rapid" (Fiasp)
     // useCustomPeakTime:false // allows changing insulinPeakTime
     // insulinPeakTime:75 // number of minutes after a bolus activity peaks.  defaults to 55m for Fiasp if useCustomPeakTime: false
     public final static int carbsReqThreshold = 1; // grams of carbsReq to trigger a pushover
     // offline_hotspot:false // enabled an offline-only local wifi hotspot if no Internet available
+    public final static double bolus_increment = 0.1; // minimum bolus that can be delivered as an SMB
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -804,7 +804,7 @@
     <string name="smbmaxminutes_summary">Max minutes of basal to limit SMB to</string>
     <string name="uamsmbmaxminutes" translatable="false">45 60 75 90 105 120</string>
     <string name="uamsmbmaxminutes_summary">Max minutes of basal to limit SMB to for UAM</string>
-    <string name="bolus_increment" translatable="false">0.1</string>
+    <string name="key_bolus_increment" translatable="false">bolus_increment</string>
     <string name="bolus_increment_summary">Minimum bolus that can be delivered as an SMB</string>
     <string name="unsupportedfirmware">Unsupported pump firmware</string>
     <string name="dexcomg5_xdripupload_title">Send BG data to xDrip+</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -803,7 +803,8 @@
     <string name="smbmaxminutes" translatable="false">45 60 75 90 105 120</string>
     <string name="smbmaxminutes_summary">Max minutes of basal to limit SMB to</string>
     <string name="uamsmbmaxminutes" translatable="false">45 60 75 90 105 120</string>
-    <string name="uamsmbmaxminutes_summary">Max minutes of basal to limit SMB to when UAM is active</string>
+    <string name="uamsmbmaxminutes_summary">Max minutes of basal to limit SMB to for UAM</string>
+    <string name="bolus_increment_summary">Minimum bolus that can be delivered as an SMB</string>
     <string name="unsupportedfirmware">Unsupported pump firmware</string>
     <string name="dexcomg5_xdripupload_title">Send BG data to xDrip+</string>
     <string name="key_dexcomg5_xdripupload" translatable="false">dexcomg5_xdripupload</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -804,6 +804,7 @@
     <string name="smbmaxminutes_summary">Max minutes of basal to limit SMB to</string>
     <string name="uamsmbmaxminutes" translatable="false">45 60 75 90 105 120</string>
     <string name="uamsmbmaxminutes_summary">Max minutes of basal to limit SMB to for UAM</string>
+    <string name="bolus_increment" translatable="false">0.1</string>
     <string name="bolus_increment_summary">Minimum bolus that can be delivered as an SMB</string>
     <string name="unsupportedfirmware">Unsupported pump firmware</string>
     <string name="dexcomg5_xdripupload_title">Send BG data to xDrip+</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -802,6 +802,8 @@
     <string name="wear_detailed_delta_summary">Show delta with one more decimal place</string>
     <string name="smbmaxminutes" translatable="false">45 60 75 90 105 120</string>
     <string name="smbmaxminutes_summary">Max minutes of basal to limit SMB to</string>
+    <string name="uamsmbmaxminutes" translatable="false">45 60 75 90 105 120</string>
+    <string name="uamsmbmaxminutes_summary">Max minutes of basal to limit SMB to when UAM is active</string>
     <string name="unsupportedfirmware">Unsupported pump firmware</string>
     <string name="dexcomg5_xdripupload_title">Send BG data to xDrip+</string>
     <string name="key_dexcomg5_xdripupload" translatable="false">dexcomg5_xdripupload</string>

--- a/app/src/main/res/xml/pref_openapssmb.xml
+++ b/app/src/main/res/xml/pref_openapssmb.xml
@@ -96,7 +96,7 @@
         <com.andreabaccega.widget.ValidatingEditTextPreference
                 android:defaultValue="0.1"
                 android:inputType="numberDecimal"
-                android:key="@string/bolus_increment"
+                android:key="key_bolus_increment"
                 android:maxLines="20"
                 android:selectAllOnFocus="true"
                 android:singleLine="true"

--- a/app/src/main/res/xml/pref_openapssmb.xml
+++ b/app/src/main/res/xml/pref_openapssmb.xml
@@ -93,6 +93,20 @@
                 validate:minNumber="15"
                 validate:testType="numericRange" />
 
+        <com.andreabaccega.widget.ValidatingEditTextPreference
+                android:defaultValue="0.1"
+                android:digits="0123456789."
+                android:inputType="numberDecimal"
+                android:maxLines="20"
+                android:key="key_bolus_increment"
+                android:selectAllOnFocus="true"
+                android:singleLine="true"
+                android:title="@string/bolus_increment_summary"
+                validate:maxNumber='1'
+                validate:minNumber='0'
+                validate:testType="floatNumericRange" />
+
+
         <SwitchPreference
             android:defaultValue="false"
             android:key="@string/key_use_uam"

--- a/app/src/main/res/xml/pref_openapssmb.xml
+++ b/app/src/main/res/xml/pref_openapssmb.xml
@@ -95,15 +95,14 @@
 
         <com.andreabaccega.widget.ValidatingEditTextPreference
                 android:defaultValue="0.1"
-                android:digits="0123456789."
-                android:inputType="number"
+                android:inputType="numberDecimal"
+                android:key="@string/bolus_increment"
                 android:maxLines="20"
-                android:key="key_bolus_increment"
                 android:selectAllOnFocus="true"
                 android:singleLine="true"
                 android:title="@string/bolus_increment_summary"
-                validate:maxNumber='1'
-                validate:minNumber='0'
+                validate:floatmaxNumber="1.0"
+                validate:floatminNumber="0.05"
                 validate:testType="floatNumericRange" />
 
 

--- a/app/src/main/res/xml/pref_openapssmb.xml
+++ b/app/src/main/res/xml/pref_openapssmb.xml
@@ -96,7 +96,7 @@
         <com.andreabaccega.widget.ValidatingEditTextPreference
                 android:defaultValue="0.1"
                 android:digits="0123456789."
-                android:inputType="numberDecimal"
+                android:inputType="number"
                 android:maxLines="20"
                 android:key="key_bolus_increment"
                 android:selectAllOnFocus="true"

--- a/app/src/main/res/xml/pref_openapssmb.xml
+++ b/app/src/main/res/xml/pref_openapssmb.xml
@@ -79,6 +79,20 @@
             validate:minNumber="15"
             validate:testType="numericRange" />
 
+        <com.andreabaccega.widget.ValidatingEditTextPreference
+                android:defaultValue="30"
+                android:dialogMessage="@string/uamsmbmaxminutes"
+                android:digits="0123456789"
+                android:inputType="number"
+                android:key="key_uamsmbmaxminutes"
+                android:maxLines="20"
+                android:selectAllOnFocus="true"
+                android:singleLine="true"
+                android:title="@string/uamsmbmaxminutes_summary"
+                validate:maxNumber="120"
+                validate:minNumber="15"
+                validate:testType="numericRange" />
+
         <SwitchPreference
             android:defaultValue="false"
             android:key="@string/key_use_uam"


### PR DESCRIPTION
This PR adds some features from oref1 master to AAPS. (nothing in this alters with oref behavior from master, just brings things up to date)

First Feature: 
maxUAMSMBBasalMinutes: This allows the system to give a more hefty smb only when UAM is detected.
By default this is set to the same amount as maxSMBBasalMinutes.

Second Feature:
A configurable min value for SMB  amount to be increased by, by default this is set to 0.1 units, but gives the option to go lower than that all the way down to 0.05units (limited to 0.05 to 1 unit), extremely usefull for people who are very sensitive to insulin but still want to enable SMB.

This PR requires translations for languages other than English....

This will be my first of many PR's to AAPS!

Cheers @MilosKozak and @AdrianLxM 



