### PR TITLE
SMB Interval addition

### DIFF
--- a/app/src/main/assets/OpenAPSSMB/determine-basal.js
+++ b/app/src/main/assets/OpenAPSSMB/determine-basal.js
@@ -1085,17 +1085,23 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             }
             rT.reason += ". ";
 
-            //allow SMBs every 3 minutes
-            var nextBolusMins = round(3-lastBolusAge,1);
+            //allow SMBs every 3 minutes by default
+            var SMBInterval = 3;
+            if (profile.SMBInterval) {
+                // allow SMBIntervals between 1 and 10 minutes
+                SMBInterval = Math.min(10,Math.max(1,profile.SMBInterval));
+            }
+            var nextBolusMins = round(SMBInterval-lastBolusAge,0);
+            var nextBolusSeconds = round((SMBInterval - lastBolusAge) * 60, 0) % 60;
             //console.error(naive_eventualBG, insulinReq, worstCaseInsulinReq, durationReq);
             console.error("naive_eventualBG",naive_eventualBG+",",durationReq+"m "+smbLowTempReq+"U/h temp needed; last bolus",lastBolusAge+"m ago; maxBolus: "+maxBolus);
-            if (lastBolusAge > 3) {
+            if (lastBolusAge > SMBInterval) {
                 if (microBolus > 0) {
                     rT.units = microBolus;
                     rT.reason += "Microbolusing " + microBolus + "U. ";
                 }
             } else {
-                rT.reason += "Waiting " + nextBolusMins + "m to microbolus again. ";
+                rT.reason += "Waiting " + nextBolusMins + "m " + nextBolusSeconds + "s to microbolus again. ";
             }
             //rT.reason += ". ";
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
@@ -249,6 +249,7 @@ public class DetermineBasalAdapterSMBJS {
         mProfile.put("remainingCarbsCap", SMBDefaults.remainingCarbsCap);
         mProfile.put("enableUAM", SP.getBoolean(R.string.key_use_uam, false));
         mProfile.put("A52_risk_enable", SMBDefaults.A52_risk_enable);
+        mProfile.put("SMBInterval", SP.getInt("key_smbinterval", SMBDefaults.SMBInterval));
         mProfile.put("enableSMB_with_COB", SP.getBoolean(R.string.key_enableSMB_with_COB, false));
         mProfile.put("enableSMB_with_temptarget", SP.getBoolean(R.string.key_enableSMB_with_temptarget, false));
         mProfile.put("allowSMB_with_high_temptarget", SP.getBoolean(R.string.key_allowSMB_with_high_temptarget, false));

--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/SMBDefaults.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/SMBDefaults.java
@@ -55,6 +55,7 @@ public class SMBDefaults {
     // *** WARNING *** DO NOT USE enableSMB_always or enableSMB_after_carbs with xDrip+, Libre, or similar
     //public final static boolean enableSMB_after_carbs = false; // enable supermicrobolus for 6h after carbs, even with 0 COB
     //public final static boolean allowSMB_with_high_temptarget = false; // allow supermicrobolus (if otherwise enabled) even with high temp targets
+    public final static int SMBInterval = 3; // minimum interval between SMBs, in minutes. (limited between 1 and 10 min)
     public final static int maxSMBBasalMinutes = 30; // maximum minutes of basal that can be delivered as a single SMB with uncovered COB
     // curve:"rapid-acting" // Supported curves: "bilinear", "rapid-acting" (Novolog, Novorapid, Humalog, Apidra) and "ultra-rapid" (Fiasp)
     // useCustomPeakTime:false // allows changing insulinPeakTime

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -800,6 +800,8 @@
     <string name="poctech_upload">Poctech upload settings</string>
     <string name="wear_detailed_delta_title">Show detailed delta</string>
     <string name="wear_detailed_delta_summary">Show delta with one more decimal place</string>
+    <string name="key_smbinterval" translatable="false">key_smbinterval</string>
+    <string name="smbinterval_summary">How frequently SMBs will be given in min</string>
     <string name="smbmaxminutes" translatable="false">45 60 75 90 105 120</string>
     <string name="smbmaxminutes_summary">Max minutes of basal to limit SMB to</string>
     <string name="unsupportedfirmware">Unsupported pump firmware</string>

--- a/app/src/main/res/xml/pref_openapssmb.xml
+++ b/app/src/main/res/xml/pref_openapssmb.xml
@@ -66,6 +66,19 @@
             android:title="@string/enablesmbaftercarbs" />
 
         <com.andreabaccega.widget.ValidatingEditTextPreference
+            android:defaultValue="3"
+            android:digits="0123456789"
+            android:inputType="number"
+            android:key="key_smbinterval"
+            android:maxLines="20"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:title="@string/smbinterval_summary"
+            validate:maxNumber="10"
+            validate:minNumber="1"
+            validate:testType="numericRange" />
+
+        <com.andreabaccega.widget.ValidatingEditTextPreference
             android:defaultValue="30"
             android:dialogMessage="@string/smbmaxminutes"
             android:digits="0123456789"


### PR DESCRIPTION
Adds another SMB feature which is current upstream versions of oref1.

The SMBInterval Parameter can restrict how frequently SMB's can be dosed, limits apply from 1 min to 10.
This can also ensure that SMB's will be able to delivered more frequently if required.

The default is 3 min which has not changed.