### PR TITLE
Get device name before setting up the callback

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRS/services/BLEComm.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpDanaRS/services/BLEComm.java
@@ -144,9 +144,9 @@ public class BLEComm {
 
         if (L.isEnabled(L.PUMPBTCOMM))
             log.debug("Trying to create a new connection from: " + from);
+        mBluetoothDeviceName = device.getName();
         mBluetoothGatt = device.connectGatt(service.getApplicationContext(), false, mGattCallback);
         setCharacteristicNotification(getUARTReadBTGattChar(), true);
-        mBluetoothDeviceName = device.getName();
         return true;
     }
 


### PR DESCRIPTION
In case the callback is very quick, the name might not have been set yet?