### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
     dependencies {


### PR DESCRIPTION
google() needs to be loaded before others.
Otherwise, you got the error-message:
> Could not find aapt2-proto.jar (com.android.tools.build:aapt2-proto:0.3.1).
> Searched in the following locations:
> https://jcenter.bintray.com/com/android/tools/build/aapt2-proto/0.3.1/aapt2-proto-0.3.1.jar