### PR TITLE
Bring set-basal up to date with oref 0.7.0

### DIFF
--- a/app/src/main/assets/OpenAPSSMB/basal-set-temp.js
+++ b/app/src/main/assets/OpenAPSSMB/basal-set-temp.js
@@ -9,33 +9,32 @@ var tempBasalFunctions = {};
 
 tempBasalFunctions.getMaxSafeBasal = function getMaxSafeBasal(profile) {
 
-	var max_daily_safety_multiplier = (isNaN(profile.max_daily_safety_multiplier) || profile.max_daily_safety_multiplier == null) ? 3 : profile.max_daily_safety_multiplier;
-	var current_basal_safety_multiplier = (isNaN(profile.current_basal_safety_multiplier) || profile.current_basal_safety_multiplier == null) ? 4 : profile.current_basal_safety_multiplier;
-	
-	return Math.min(profile.max_basal, max_daily_safety_multiplier * profile.max_daily_basal, current_basal_safety_multiplier * profile.current_basal);
+    var max_daily_safety_multiplier = (isNaN(profile.max_daily_safety_multiplier) || profile.max_daily_safety_multiplier == null) ? 3 : profile.max_daily_safety_multiplier;
+    var current_basal_safety_multiplier = (isNaN(profile.current_basal_safety_multiplier) || profile.current_basal_safety_multiplier == null) ? 4 : profile.current_basal_safety_multiplier;
+
+    return Math.min(profile.max_basal, max_daily_safety_multiplier * profile.max_daily_basal, current_basal_safety_multiplier * profile.current_basal);
 };
 
 tempBasalFunctions.setTempBasal = function setTempBasal(rate, duration, profile, rT, currenttemp) {
     //var maxSafeBasal = Math.min(profile.max_basal, 3 * profile.max_daily_basal, 4 * profile.current_basal);
-    
+
     var maxSafeBasal = tempBasalFunctions.getMaxSafeBasal(profile);
-var round_basal = require('./round-basal');
-    
-    if (rate < 0) { 
-        rate = 0; 
-    } // if >30m @ 0 required, zero temp will be extended to 30m instead
-    else if (rate > maxSafeBasal) { 
-        rate = maxSafeBasal; 
+    var round_basal = require('./round-basal');
+
+    if (rate < 0) {
+        rate = 0;
+    } else if (rate > maxSafeBasal) {
+        rate = maxSafeBasal;
     }
 
     var suggestedRate = round_basal(rate, profile);
-    if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > (duration-10) && currenttemp.duration <= 120 && suggestedRate <= currenttemp.rate * 1.2 && suggestedRate >= currenttemp.rate * 0.8) {
+    if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > (duration-10) && currenttemp.duration <= 120 && suggestedRate <= currenttemp.rate * 1.2 && suggestedRate >= currenttemp.rate * 0.8 && duration > 0 ) {
         rT.reason += " "+currenttemp.duration+"m left and " + currenttemp.rate + " ~ req " + suggestedRate + "U/hr: no temp required";
         return rT;
     }
 
     if (suggestedRate === profile.current_basal) {
-      if (profile.skip_neutral_temps) {
+      if (profile.skip_neutral_temps === true) {
         if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && currenttemp.duration > 0) {
           reason(rT, 'Suggested rate is same as profile rate, a temp basal is active, canceling current temp');
           rT.duration = 0;


### PR DESCRIPTION
This brings set-basal.js up to date with the latest oref version 0.7.0 and is a straight copy from the oref repository.
 - No significant changes made just code cleanup and additional checking of some variables.
