### PR TITLE
WIP: [untested] [for discussion] Openloop RS hotfix

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/Loop/LoopPlugin.java
@@ -306,7 +306,8 @@ public class LoopPlugin extends PluginBase {
             }
 
             // Prepare for pumps using % basals
-            if (pump.getPumpDescription().tempBasalStyle == PumpDescription.PERCENT) {
+            //TODO: So far applyTBRRequest() only allows percentages on a virtual pump. see todo there.
+            if (pump.getPumpDescription().tempBasalStyle == PumpDescription.PERCENT && VirtualPumpPlugin.getPlugin().isEnabled(PluginType.PUMP)) {
                 result.usePercent = true;
             }
             result.percent = (int) (result.rate / profile.getBasal() * 100);
@@ -476,11 +477,12 @@ public class LoopPlugin extends PluginBase {
 
     /**
      * expect absolute request and allow both absolute and percent response based on pump capabilities
-     * TODO: update pump drivers to support APS request in %
+     * TODO: update pump drivers to support APS request in %; Make sure, constraints are checked correctly as percentagea and absolute constraints are independent
      */
 
     public void applyTBRRequest(APSResult request, Profile profile, Callback callback) {
-        boolean allowPercentage = VirtualPumpPlugin.getPlugin().isEnabled(PluginType.PUMP);
+        //TODO: even on a virtual pump not all pumps can support percentage. Use the same one -> && request.usePercent
+        boolean allowPercentage = VirtualPumpPlugin.getPlugin().isEnabled(PluginType.PUMP) && request.usePercent;
 
         if (!request.tempBasalRequested) {
             if (callback != null) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/PumpCommon/defs/PumpType.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/PumpCommon/defs/PumpType.java
@@ -77,7 +77,7 @@ public enum PumpType {
     DanaRS("DanaRS", 0.05d, null, //
             new DoseSettings(0.05d, 30, 8*60, 0.05d), //
             PumpTempBasalType.Percent, //
-            new DoseSettings(10d, 60, 24*60, 0d, 200d), PumpCapability.BasalRate_Duration15and30minAllowed, //
+            new DoseSettings(10d, 60, 24*60, 0d, 500d), PumpCapability.BasalRate_Duration15and30minAllowed, //
             0.04d, 0.01d, null, PumpCapability.DanaWithHistoryCapabilities),
 
     DanaRv2("DanaRv2", DanaRS),


### PR DESCRIPTION
This is a hotfix.

applyTBRRequest only sets the TBR in percentage if on a virtual pump.
1) Make the APSRequest show that beforehand.
2) Now with different pumps available for virtual pumps: Not always use the percentage - only if the pump supports it.

In fact the pump driver of the RS will accept the absolute rate, calculate the percentage off it and then call `setTempBasalPercent()`. So ideally we should use the percentage form here.
I decided not to do so as this way is a) tested and b) the dynamic constraint `DanaRPump.maxBasal` that is read from the pump only applies for absolute rates and would need more changes as well.