### PR TITLE
add basal total view to nightscout-profile

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/ProfileNS/NSProfileFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/ProfileNS/NSProfileFragment.java
@@ -52,6 +52,8 @@ public class NSProfileFragment extends SubscriberFragment {
     TextView isf;
     @BindView(R.id.profileview_basal)
     TextView basal;
+    @BindView(R.id.profileview_basaltotal)
+    TextView basaltotal;
     @BindView(R.id.profileview_target)
     TextView target;
     @BindView(R.id.basal_graph)
@@ -116,6 +118,7 @@ public class NSProfileFragment extends SubscriberFragment {
                 ic.setText(profile.getIcList());
                 isf.setText(profile.getIsfList());
                 basal.setText(profile.getBasalList());
+                basaltotal.setText("==   ∑ " + DecimalFormatter.to2Decimal(profile.baseBasalSum()) + "U");
                 target.setText(profile.getTargetList());
                 basalGraph.show(profile);
             }
@@ -141,6 +144,7 @@ public class NSProfileFragment extends SubscriberFragment {
         ic.setText("");
         isf.setText("");
         basal.setText("");
+        basaltotal.setText("");
         target.setText("");
         activateButton.setVisibility(View.GONE);
     }

--- a/app/src/main/res/layout/profileviewer_fragment.xml
+++ b/app/src/main/res/layout/profileviewer_fragment.xml
@@ -345,6 +345,43 @@
 
             </LinearLayout>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:gravity="end"
+                    android:paddingRight="5dp"
+                    android:text=""
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingEnd="2dp"
+                    android:paddingStart="2dp"
+                    android:text=""
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:id="@+id/profileview_basaltotal"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="24dp"
+                    android:layout_weight="1"
+                    android:gravity="start"
+                    android:paddingLeft="5dp"
+                    android:textColor="@android:color/white"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
             <info.nightscout.androidaps.plugins.Treatments.fragments.ProfileGraph
                 android:id="@+id/basal_graph"
                 android:layout_width="match_parent"


### PR DESCRIPTION
basalTotal view already exists in localprofile.
Also added to nightscout-profile view.

Please check that I have not overlooked anything.
For my aaps (dev) it works:

![screenshot nightscout profile](https://www2.pic-upload.de/img/36231886/Screenshot_2018-11-06-23-41-28-172_info.nightscout.androidaps.png)
==   ∑ 22,50U (on my profile)

