### PR TITLE
Bugfix: only allow SMB if parent preference is enabled.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/OpenAPSSMB/DetermineBasalAdapterSMBJS.java
@@ -250,11 +250,13 @@ public class DetermineBasalAdapterSMBJS {
         mProfile.put("remainingCarbsCap", SMBDefaults.remainingCarbsCap);
         mProfile.put("enableUAM", uamAllowed);
         mProfile.put("A52_risk_enable", SMBDefaults.A52_risk_enable);
-        mProfile.put("enableSMB_with_COB", SP.getBoolean(R.string.key_enableSMB_with_COB, false));
-        mProfile.put("enableSMB_with_temptarget", SP.getBoolean(R.string.key_enableSMB_with_temptarget, false));
-        mProfile.put("allowSMB_with_high_temptarget", SP.getBoolean(R.string.key_allowSMB_with_high_temptarget, false));
-        mProfile.put("enableSMB_always", SP.getBoolean(R.string.key_enableSMB_always, false) && advancedFiltering);
-        mProfile.put("enableSMB_after_carbs", SP.getBoolean(R.string.key_enableSMB_after_carbs, false) && advancedFiltering);
+
+        boolean smbEnabled = SP.getBoolean(MainApp.gs(R.string.key_use_smb), false);
+        mProfile.put("enableSMB_with_COB", smbEnabled && SP.getBoolean(R.string.key_enableSMB_with_COB, false));
+        mProfile.put("enableSMB_with_temptarget", smbEnabled && SP.getBoolean(R.string.key_enableSMB_with_temptarget, false));
+        mProfile.put("allowSMB_with_high_temptarget", smbEnabled && SP.getBoolean(R.string.key_allowSMB_with_high_temptarget, false));
+        mProfile.put("enableSMB_always", smbEnabled && SP.getBoolean(R.string.key_enableSMB_always, false) && advancedFiltering);
+        mProfile.put("enableSMB_after_carbs", smbEnabled && SP.getBoolean(R.string.key_enableSMB_after_carbs, false) && advancedFiltering);
         mProfile.put("maxSMBBasalMinutes", SP.getInt(R.string.key_smbmaxminutes, SMBDefaults.maxSMBBasalMinutes));
         mProfile.put("carbsReqThreshold", SMBDefaults.carbsReqThreshold);
 


### PR DESCRIPTION
Some users reported SMBs being enabled after activating Objective 8, without explicitly enabling SMB.

The pref _Enable SMB_ (key_use_smb) is subject to constraints and is handed over to OpenAPS as _microBolusAllowed_, which is a global flag to enable/disable SMBs. This alone should prevent SMBs if the pref is not set, however this seems to have occurred. I traced the code path but was unable to determine the cause. It should work correctly. There is a test which confirms this.

OpenAPS doses SMBs if the above mentioned flag is true and if either of the more detailed _enableSMB*_ flags is set. This change aligns the input to OpenAPS to what the user sees in the prefs: if the main _Enable SMB_ flag is off, all detailed flags will be off as well. This should effectively prevent the reported behaviour, since OpenAPS only doses SMBs if both _microBolusAllowed_ is true and one of the _enableSMB*_ flags is set.

Manually tested to assert SMBs are dosed if enabled but not when _Enable SMB_ is off, regardless of state of detailed prefs.