### PR TITLE
Fixed: Use bage instead of pgage variable for coloring the battery age in careportal.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/careportal/CareportalFragment.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/careportal/CareportalFragment.java
@@ -229,8 +229,8 @@ public class CareportalFragment extends SubscriberFragment implements View.OnCli
                         double sageWarn = nsSettings.getExtendedWarnValue("sage", "warn", 164);
                         handleAge(sage, CareportalEvent.SENSORCHANGE, sageWarn, sageUrgent);
 
-                        double pbageUrgent = nsSettings.getExtendedWarnValue("pgage", "urgent", 360);
-                        double pbageWarn = nsSettings.getExtendedWarnValue("pgage", "warn", 240);
+                        double pbageUrgent = nsSettings.getExtendedWarnValue("bage", "urgent", 360);
+                        double pbageWarn = nsSettings.getExtendedWarnValue("bage", "warn", 240);
                         handleAge(pbage, CareportalEvent.PUMPBATTERYCHANGE, pbageWarn, pbageUrgent);
                     }
             );


### PR DESCRIPTION
This pull requests needs documentation changes, which were requested by PullRequest https://github.com/openaps/AndroidAPSdocs/pull/289
