### PR TITLE
Calculate deltas correctly with 1 minute spaced data

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/data/GlucoseStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/data/GlucoseStatus.java
@@ -127,9 +127,7 @@ public class GlucoseStatus {
                     // long_deltas are calculated from everything ~20-40 minutes ago
                 } else if (17.5 < minutesago && minutesago < 42.5) {
                     long_deltas.add(avgdelta);
-                }
-                else
-                {
+                } else {
                     // Do not process any more records after >= 42.5 minutes
                     break;
                 }

--- a/app/src/main/java/info/nightscout/androidaps/data/GlucoseStatus.java
+++ b/app/src/main/java/info/nightscout/androidaps/data/GlucoseStatus.java
@@ -72,8 +72,6 @@ public class GlucoseStatus {
             return null;
         }
 
-        sizeRecords = Math.min(sizeRecords, 9);
-
         if (data.get(0).date < DateUtil.now() - 7 * 60 * 1000L && !allowOldData) {
             return null;
         }
@@ -93,9 +91,13 @@ public class GlucoseStatus {
             return status.round();
         }
 
+        ArrayList<Double> now_value_list = new ArrayList<Double>();
         ArrayList<Double> last_deltas = new ArrayList<Double>();
         ArrayList<Double> short_deltas = new ArrayList<Double>();
         ArrayList<Double> long_deltas = new ArrayList<Double>();
+
+        // Use the latest sgv value in the now calculations
+        now_value_list.add(now.value);
 
         for (int i = 1; i < sizeRecords; i++) {
             if (data.get(i).value > 38) {
@@ -111,8 +113,9 @@ public class GlucoseStatus {
 
                 // use the average of all data points in the last 2.5m for all further "now" calculations
                 if (0 < minutesago && minutesago < 2.5) {
-                    now.value = (now.value + then.value) / 2;
-                    now_date = (now_date + then_date) / 2;
+                    // Keep and average all values within the last 2.5 minutes
+                    now_value_list.add(then.value);
+                    now.value = average(now_value_list);
                     // short_deltas are calculated from everything ~5-15 minutes ago
                 } else if (2.5 < minutesago && minutesago < 17.5) {
                     //console.error(minutesago, avgdelta);
@@ -124,6 +127,11 @@ public class GlucoseStatus {
                     // long_deltas are calculated from everything ~20-40 minutes ago
                 } else if (17.5 < minutesago && minutesago < 42.5) {
                     long_deltas.add(avgdelta);
+                }
+                else
+                {
+                    // Do not process any more records after >= 42.5 minutes
+                    break;
                 }
             }
         }


### PR DESCRIPTION
  * Remove hard limit of processing 9 records.  Processing will now stop
    at first value outside of time range of interest
  * Keep a list of all values within 2.5 minutes.  Average this value to use
    as the now value
  * Don't change the now value date.  Always use the time of the latest value
  * Added new test for data spaced at 1 minute intervals, to mimic libre data from glimp
  * Fix existing test results for average < 2.5 minute data. Deltas are different due to
    not updating the now value time