### PR TITLE
Insight: Fix automatic Careportal entries

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
@@ -1189,6 +1189,7 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
     }
 
     private void processCannulaFilledEvent(CannulaFilledEvent event) {
+        if (!SP.getBoolean("insight_log_site_changes", false)) return;
         long timestamp = parseDate(event.getEventYear(), event.getEventMonth(), event.getEventDay(),
                 event.getEventHour(), event.getEventMinute(), event.getEventSecond()) + timeOffset;
         uploadCareportalEvent(timestamp, CareportalEvent.SITECHANGE);
@@ -1216,7 +1217,7 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
     }
 
     private void processSniffingDoneEvent(SniffingDoneEvent event) {
-        if (!SP.getBoolean("insight_log_site_changes", false)) return;
+        if (!SP.getBoolean("insight_log_reservoir_changes", false)) return;
         long timestamp = parseDate(event.getEventYear(), event.getEventMonth(), event.getEventDay(),
                 event.getEventHour(), event.getEventMinute(), event.getEventSecond()) + timeOffset;
         uploadCareportalEvent(timestamp, CareportalEvent.INSULINCHANGE);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1253,6 +1253,7 @@
     <string name="mute_alert">Mute</string>
     <string name="pump_alert">Pump alert</string>
     <string name="log_site_changes">Log site changes</string>
+    <string name="log_reservoir_changes">Log reservoir changes</string>
     <string name="log_tube_changes">Log tube changes</string>
     <string name="log_battery_changes">Log battery changes</string>
     <string name="log_operating_mode_changes">Log operating mode changes</string>

--- a/app/src/main/res/xml/pref_insight_local.xml
+++ b/app/src/main/res/xml/pref_insight_local.xml
@@ -10,13 +10,18 @@
 
         <SwitchPreference
             android:defaultValue="false"
-            android:key="insight_log_site_changes"
-            android:title="@string/log_site_changes" />
+            android:key="insight_log_reservoir_changes"
+            android:title="@string/log_reservoir_changes" />
 
         <SwitchPreference
             android:defaultValue="false"
             android:key="insight_log_tube_changes"
             android:title="@string/log_tube_changes" />
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="insight_log_site_changes"
+            android:title="@string/log_site_changes" />
 
         <SwitchPreference
             android:defaultValue="false"


### PR DESCRIPTION
This fixes the following issues:

- The automatic logging of reservoir changes was handled by the cannula setting.
- The cannula setting was effectively missing.