### PR TITLE
Split up receivers for local BG broadcasts and SMS.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,31 +73,40 @@
         <activity android:name=".plugins.pump.danaRS.activities.PairingHelperActivity" />
         <activity android:name=".activities.HistoryBrowseActivity" />
 
+        <!-- Receive new BG readings from other local aaps -->
         <receiver
-            android:name=".receivers.DataReceiver"
-            android:enabled="true"
-            android:exported="true"
-            android:permission="android.permission.BROADCAST_SMS">
+                android:name=".receivers.DataReceiver"
+                android:enabled="true"
+                android:exported="true">
             <intent-filter>
-
-                <!-- Receive new SMS messages -->
-                <action android:name="android.provider.Telephony.SMS_RECEIVED" />
                 <!-- Receiver from xDrip -->
-                <action android:name="com.eveningoutpost.dexdrip.BgEstimate" />
+                <action android:name="com.eveningoutpost.dexdrip.BgEstimate"/>
                 <!-- Receiver from 640g uploader -->
-                <action android:name="com.eveningoutpost.dexdrip.NS_EMULATOR" />
+                <action android:name="com.eveningoutpost.dexdrip.NS_EMULATOR"/>
                 <!-- Receiver from glimp -->
-                <action android:name="it.ct.glicemia.ACTION_GLUCOSE_MEASURED" />
+                <action android:name="it.ct.glicemia.ACTION_GLUCOSE_MEASURED"/>
                 <!-- Receiver from DexcomG5 -->
-                <action android:name="com.dexcom.cgm.DATA" />
-                <action android:name="com.dexcom.cgm.AndroidAPSEVGCallback.BROADCAST" />
-                <action android:name="com.dexcom.cgm.g5.AndroidAPSEVGCallback.BROADCAST" />
+                <action android:name="com.dexcom.cgm.DATA"/>
+                <action android:name="com.dexcom.cgm.AndroidAPSEVGCallback.BROADCAST"/>
+                <action android:name="com.dexcom.cgm.g5.AndroidAPSEVGCallback.BROADCAST"/>
                 <!-- Receiver from Poctech -->
-                <action android:name="com.china.poctech.data" />
+                <action android:name="com.china.poctech.data"/>
                 <!-- Receiver from Tomato -->
-                <action android:name="com.fanqies.tomatofn.BgEstimate" />
+                <action android:name="com.fanqies.tomatofn.BgEstimate"/>
             </intent-filter>
         </receiver>
+
+        <!-- Receive new SMS messages -->
+        <receiver
+                android:name=".receivers.SmsReceiver"
+                android:enabled="true"
+                android:exported="true"
+                android:permission="android.permission.BROADCAST_SMS">
+            <intent-filter>
+                <action android:name="android.provider.Telephony.SMS_RECEIVED"/>
+            </intent-filter>
+        </receiver>
+
         <!-- Receiver keepalive, scheduled every 30 min -->
         <receiver android:name=".receivers.KeepAliveReceiver" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,7 +73,7 @@
         <activity android:name=".plugins.pump.danaRS.activities.PairingHelperActivity" />
         <activity android:name=".activities.HistoryBrowseActivity" />
 
-        <!-- Receive new BG readings from other local aaps -->
+        <!-- Receive new BG readings from other local apps -->
         <receiver
                 android:name=".receivers.DataReceiver"
                 android:enabled="true"

--- a/app/src/main/java/info/nightscout/androidaps/receivers/SmsReceiver.java
+++ b/app/src/main/java/info/nightscout/androidaps/receivers/SmsReceiver.java
@@ -1,0 +1,3 @@
+package info.nightscout.androidaps.receivers;
+
+public class SmsReceiver extends DataReceiver {}

--- a/app/src/main/java/info/nightscout/androidaps/receivers/SmsReceiver.java
+++ b/app/src/main/java/info/nightscout/androidaps/receivers/SmsReceiver.java
@@ -1,3 +1,7 @@
 package info.nightscout.androidaps.receivers;
 
+/**
+ * Forward received SMS intents. This is a separate class, because unlike local broadcasts handled by DataReceiver,
+ * receiving SMS requires a special permission in the manifest, which necessitates a separate receiver.
+ */
 public class SmsReceiver extends DataReceiver {}


### PR DESCRIPTION
Receiving local BG values probably fails silently when SMS
permission is not granted (due to SMS plugin not being used).

Many thanks (once more) to Jotomo who has fixed https://github.com/MilosKozak/AndroidAPS/issues/1740
