### PR TITLE
Bugfix, Combo: recovery after encountering an unknown menu

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ruffyscripter/RuffyScripter.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ruffyscripter/RuffyScripter.java
@@ -242,6 +242,7 @@ public class RuffyScripter implements RuffyCommands {
             Thread cmdThread = null;
             try {
                 activeCmd = cmd;
+                unparsableMenuEncountered = false;
                 long connectStart = System.currentTimeMillis();
                 ensureConnected();
                 log.debug("Connection ready to execute cmd " + cmd);


### PR DESCRIPTION
When the pump is stopped, the driver might encounter menus on the pump it can't and needn't parse (change cartridge etc). In that situation the driver aborts the command. However, the flag indicating that an unknown menu was encountered was never reset prior to this commit, so all following commands would fail instantly (via the monitoring loop in _RuffyScripter.runCommand_).
The situation in which this behavior was observed, was the attempt to read the quick info menu while the pump was stopped. This usually works, but can fail apparently - the effect is negligible, it only delays the update of the pump reservoir level in the UI. But it obviously shouldn't make all subsequent commands fail.