### PR TITLE
Log an uncaught exception before it crashes the app.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/MainApp.java
+++ b/app/src/main/java/info/nightscout/androidaps/MainApp.java
@@ -139,6 +139,8 @@ public class MainApp extends Application {
         sConstraintsChecker = new ConstraintChecker();
         sDatabaseHelper = OpenHelperManager.getHelper(sInstance, DatabaseHelper.class);
 
+        Thread.setDefaultUncaughtExceptionHandler((thread, ex) -> log.error("Uncaught exception crashing app", ex));
+
         try {
             if (FabricPrivacy.fabricEnabled()) {
                 Fabric.with(this, new Crashlytics());


### PR DESCRIPTION
According to https://fabric.io/kits/android/crashlytics/features (Step 3, 2nd paragraph), registering an UncaughtExceptionHandler before Fabric is set up does not interfere with Fabric.

This will help getting access to stracktraces (via the log) which otherwise are only visible via logcat.