### PR TITLE
Clean up log output from determine-basal.js

### DIFF
--- a/app/src/main/assets/OpenAPSAMA/loggerhelper.js
+++ b/app/src/main/assets/OpenAPSAMA/loggerhelper.js
@@ -1,12 +1,33 @@
 var console = { };
 console.error =  function error(){
+    var s = '';
 	for (var i = 0, len = arguments.length; i < len; i++) {
-		console2.log(arguments[i]);
+	    if (i > 0) s = s + ' ';
+	    if (typeof arguments[i] === 'undefined') {
+            s = s + 'undefined';
+	    } else if (typeof arguments[i] === 'object') {
+	        s = s + JSON.stringify(arguments[i]);
+	    } else {
+            s = s + arguments[i].toString();
+        }
 	}
+	s = s + "\n";
+	console2.log(s);
 };
 
 console.log =  function log(){
+    var s = '';
 	for (var i = 0, len = arguments.length; i < len; i++) {
-		console2.log(arguments[i]);
+	    if (i > 0) s = s + ' ';
+	    if (typeof arguments[i] === 'undefined') {
+            s = s + 'undefined';
+	    } else if (typeof arguments[i] === 'object') {
+	        s = s + JSON.stringify(arguments[i]);
+	    } else {
+            s = s + arguments[i].toString();
+        }
+		//console2.log(arguments[i]);
 	}
+	s = s + "\n";
+	console2.log(s);
 };

--- a/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSMA/LoggerCallback.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSMA/LoggerCallback.java
@@ -38,14 +38,12 @@ public class LoggerCallback extends ScriptableObject {
         if (L.isEnabled(L.APS))
             log.debug(obj1.toString().trim());
         logBuffer.append(obj1.toString());
-//        logBuffer.append(' ');
     }
 
     public void jsFunction_error(Object obj1) {
         if (L.isEnabled(L.APS))
             log.error(obj1.toString().trim());
         errorBuffer.append(obj1.toString());
-//        errorBuffer.append(' ');
     }
 
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSMA/LoggerCallback.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSMA/LoggerCallback.java
@@ -36,16 +36,16 @@ public class LoggerCallback extends ScriptableObject {
 
     public void jsFunction_log(Object obj1) {
         if (L.isEnabled(L.APS))
-            log.debug(obj1.toString());
+            log.debug(obj1.toString().trim());
         logBuffer.append(obj1.toString());
-        logBuffer.append(' ');
+//        logBuffer.append(' ');
     }
 
     public void jsFunction_error(Object obj1) {
         if (L.isEnabled(L.APS))
-            log.error(obj1.toString());
+            log.error(obj1.toString().trim());
         errorBuffer.append(obj1.toString());
-        errorBuffer.append(' ');
+//        errorBuffer.append(' ');
     }
 
 


### PR DESCRIPTION
Attempt to preserve linebreaks / spaces to match output from orefo when used in OpenAPS