### PR TITLE
Fix crash in preferences for NSClient builds

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/activities/PreferencesActivity.java
+++ b/app/src/main/java/info/nightscout/androidaps/activities/PreferencesActivity.java
@@ -209,6 +209,7 @@ public class PreferencesActivity extends PreferenceActivity implements SharedPre
                     scrnAdvancedSettings.removePreference(getPreference(getString(R.string.key_statuslights_bat_warning)));
                     scrnAdvancedSettings.removePreference(getPreference(getString(R.string.key_statuslights_bat_critical)));
                     scrnAdvancedSettings.removePreference(getPreference(getString(R.string.key_show_statuslights)));
+                    scrnAdvancedSettings.removePreference(getPreference(getString(R.string.key_show_statuslights_extended)));
                 }
             }
 


### PR DESCRIPTION
NSClient builds would crash when opening the overview preferences after new preference options were added in https://github.com/MilosKozak/AndroidAPS/commit/cc298f81b80d37f4f81d79f5592fc808a3bb6857. I believe this is related to #2079 

The preferences activity would remove the `key_show_statuslights` preference but not `key_show_statuslights_extended` causing the app to crash since the dependent preference could not be found. This PR simply adds `key_show_statuslights_extended` to the list of removed preferences when using an NSClient flavor of the app which fixes the issue.