### PR TITLE
Recalculate IOB on insulin peak time pref change.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/IobCobCalculatorPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/IobCobCalculatorPlugin.java
@@ -164,7 +164,8 @@ public class IobCobCalculatorPlugin extends PluginBase {
                             event.isChanged(R.string.key_openapsama_min_5m_carbimpact) ||
                             event.isChanged(R.string.key_absorption_cutoff) ||
                             event.isChanged(R.string.key_openapsama_autosens_max) ||
-                            event.isChanged(R.string.key_openapsama_autosens_min)
+                            event.isChanged(R.string.key_openapsama_autosens_min) ||
+                            event.isChanged(R.string.key_insulin_oref_peak)
                     ) {
                         stopCalculation("onEventPreferenceChange");
                         synchronized (dataLock) {


### PR DESCRIPTION
Recalculate IOB etc when insulin peak time changes (Plugin Insulin Free-Peak Oref0).
Updates Insulin Activity in graph and input to OpenAPS.

This is minor and low priority (user-base of this pref is probably tiny).