### PR TITLE
Add possibility to show Battery info in days instead of percent

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/StatuslightHandler.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/StatuslightHandler.java
@@ -12,6 +12,7 @@ import info.nightscout.androidaps.interfaces.PumpInterface;
 import info.nightscout.androidaps.plugins.configBuilder.ConfigBuilderPlugin;
 import info.nightscout.androidaps.plugins.general.careportal.CareportalFragment;
 import info.nightscout.androidaps.plugins.general.nsclient.data.NSSettingsStatus;
+import info.nightscout.androidaps.plugins.pump.common.defs.PumpType;
 import info.nightscout.androidaps.utils.DecimalFormatter;
 import info.nightscout.androidaps.utils.SP;
 import info.nightscout.androidaps.utils.SetWarnColor;
@@ -34,10 +35,14 @@ class StatuslightHandler {
 
         applyStatuslight("sage", CareportalEvent.SENSORCHANGE, sageView, "SEN", 164, 166);
 
-        double batteryLevel = pump.isInitialized() ? pump.getBatteryLevel() : -1;
-        applyStatuslightLevel(R.string.key_statuslights_bat_critical, 5.0,
-                R.string.key_statuslights_bat_warning, 22.0,
-                batteryView, "BAT", batteryLevel);
+        if (pump.model() != PumpType.AccuChekCombo) {
+            double batteryLevel = pump.isInitialized() ? pump.getBatteryLevel() : -1;
+            applyStatuslightLevel(R.string.key_statuslights_bat_critical, 5.0,
+                    R.string.key_statuslights_bat_warning, 22.0,
+                    batteryView, "BAT", batteryLevel);
+        } else {
+            applyStatuslight("page", CareportalEvent.PUMPBATTERYCHANGE, batteryView, "BAT", 504, 240);
+        }
 
     }
 
@@ -105,9 +110,14 @@ class StatuslightHandler {
         handleAge("sage", CareportalEvent.SENSORCHANGE, sageView, "SEN ",
                 164, 166);
 
-        handleLevel(R.string.key_statuslights_bat_critical, 26.0,
-                R.string.key_statuslights_bat_warning, 51.0,
-                batteryView, "BAT ", pump.getBatteryLevel());
+        if (pump.model() != PumpType.AccuChekCombo) {
+            handleLevel(R.string.key_statuslights_bat_critical, 26.0,
+                    R.string.key_statuslights_bat_warning, 51.0,
+                    batteryView, "BAT ", pump.getBatteryLevel());
+        } else {
+            handleAge("bage", CareportalEvent.PUMPBATTERYCHANGE, batteryView, "BAT ",
+                    336, 240);
+        }
     }
 
     void handleAge(String nsSettingPlugin, String eventName, TextView view, String text,

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/StatuslightHandler.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/StatuslightHandler.java
@@ -41,7 +41,7 @@ class StatuslightHandler {
                     R.string.key_statuslights_bat_warning, 22.0,
                     batteryView, "BAT", batteryLevel);
         } else {
-            applyStatuslight("page", CareportalEvent.PUMPBATTERYCHANGE, batteryView, "BAT", 504, 240);
+            applyStatuslight("bage", CareportalEvent.PUMPBATTERYCHANGE, batteryView, "BAT", 504, 240);
         }
 
     }


### PR DESCRIPTION
Battery info for Combo in Percent is not so helpful.
Better is to see the numbers of battery days, So I added an option to enable this.

Before:

![2019-11-01 21 38 16-2](https://user-images.githubusercontent.com/24234385/68055278-9396e080-fcf0-11e9-8f73-39da37954506.jpg)

After:

![2019-11-01 21 37 51-1](https://user-images.githubusercontent.com/24234385/68055300-a0b3cf80-fcf0-11e9-94c4-5540b3aa56cc.jpg)
