### PR TITLE
Typo with Daylight Savings Time strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1331,9 +1331,9 @@
     <string name="tidepool_upload_bg">Upload BG tests</string>
 
     <string name="key_smbmaxminutes" translatable="false">smbmaxminutes</string>
-    <string name="dst_plugin_name" translatable="false">Dayligh Saving time</string>
-    <string name="dst_in_24h_warning">Dayligh Saving time change in 24h or less</string>
-    <string name="dst_loop_disabled_warning">Daylight saving time change less than 3 hours ago - Closed loop disabled</string>
+    <string name="dst_plugin_name" translatable="false">Daylight Saving time</string>
+    <string name="dst_in_24h_warning">Daylight Saving time change in 24h or less</string>
+    <string name="dst_loop_disabled_warning">Daylight Saving time change less than 3 hours ago - Closed loop disabled</string>
     <string name="storage">internal storage constraint</string>
     <string name="diskfull">Free at least %1$d MB from internal storage! Loop disabled!</string>
     <string name="wrongformat">Wrong format</string>


### PR DESCRIPTION
-2 strings with Daylight missing a 't'
-Savings not capitalized in the 3 string