### PR TITLE
Add strings for short_days & hours of status lights

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/db/CareportalEvent.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/CareportalEvent.java
@@ -100,8 +100,8 @@ public class CareportalEvent implements DataPointWithLabelInterface, Interval {
         String hours = " " + MainApp.gs(R.string.hours) + " ";
 
         if (useShortText) {
-            days = "d";
-            hours = "h";
+            days = MainApp.gs(R.string.days_short);
+            hours = MainApp.gs(R.string.hours_short);
         }
 
         return diff.get(TimeUnit.DAYS) + days + diff.get(TimeUnit.HOURS) + hours;

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -130,6 +130,7 @@
     <string name="configbuilder_general_description">Quelques modules d\'extension que vous pourriez trouver utiles.</string>
     <string name="configbuilder_constraints_description">Quelles restrictions sont appliquées ?</string>
     <string name="days">jours</string>
+    <string name="days_short">j</string>
     <string name="constraints">Restrictions</string>
     <string name="loop">Boucle</string>
     <string name="configbuilder_loop">Boucle</string>
@@ -575,6 +576,7 @@ L\'ENSEMBLE DES RISQUES LIÉS À LA QUALITÉ ET À LA PERFORMANCE DU PROGRAMME S
     <string name="careportal_canulaage_label">Age Cathéter</string>
     <string name="careportal_insulinage_label">Age Insuline</string>
     <string name="hours">heures</string>
+    <string name="hours_short">h</string>
     <string name="overview_newtempbasal_basaltype_label">Type du Basal</string>
     <string name="invalidprofile">Profil incorrect !!!</string>
     <string name="profileswitch">Changement Profil</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,6 +156,7 @@
     <string name="configbuilder_general_description">These are some general plugins you might find useful.</string>
     <string name="configbuilder_constraints_description">Which constraints are applied?</string>
     <string name="days">days</string>
+    <string name="days_short">d</string>
     <string name="constraints">Constraints</string>
 
     <string name="loop">Loop</string>
@@ -641,6 +642,7 @@
     <string name="careportal_canulaage_label">Canula age</string>
     <string name="careportal_insulinage_label">Insulin age</string>
     <string name="hours">hours</string>
+    <string name="hours_short">h</string>
     <string name="overview_newtempbasal_basaltype_label">Basal type</string>
     <string name="invalidprofile">Invalid profile !!!</string>
     <string name="profileswitch">ProfileSwitch</string>


### PR DESCRIPTION
My first Pull Request ;-)
I add 2 strings days_short and hours_short for translation of time of status lights (cf https://github.com/MilosKozak/AndroidAPS/issues/2127 )
Modification made in original strings .xml and in french for testing