### PR TITLE
Add shortday in strings for translation (v2)

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/db/CareportalEvent.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/CareportalEvent.java
@@ -100,8 +100,8 @@ public class CareportalEvent implements DataPointWithLabelInterface, Interval {
         String hours = " " + MainApp.gs(R.string.hours) + " ";
 
         if (useShortText) {
-            days = "d";
-            hours = "h";
+            days = MainApp.gs(R.string.shortday);
+            hours = MainApp.gs(R.string.shorthour);
         }
 
         return diff.get(TimeUnit.DAYS) + days + diff.get(TimeUnit.HOURS) + hours;

--- a/app/src/main/java/info/nightscout/androidaps/utils/DateUtil.java
+++ b/app/src/main/java/info/nightscout/androidaps/utils/DateUtil.java
@@ -185,7 +185,7 @@ public class DateUtil {
         long remainingTimeMinutes = timeInMillis / (1000 * 60);
         long remainingTimeHours = remainingTimeMinutes / 60;
         remainingTimeMinutes = remainingTimeMinutes % 60;
-        return "(" + ((remainingTimeHours > 0) ? (remainingTimeHours + "h ") : "") + remainingTimeMinutes + "')";
+        return "(" + ((remainingTimeHours > 0) ? (remainingTimeHours + MainApp.gs(R.string.shorthour) + " ") : "") + remainingTimeMinutes + "')";
     }
 
     public static String sinceString(long timestamp) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -778,6 +778,7 @@
     <string name="shortgramm">g</string>
     <string name="shortminute">m</string>
     <string name="shorthour">h</string>
+    <string name="shortday">d</string>
     <string name="none"><![CDATA[<none>]]></string>
     <string name="shortkilojoul">kJ</string>
     <string name="shortenergy">En</string>


### PR DESCRIPTION
I saw that "shorthour" allready exists in strings, so I just add one string for shortday.
I changed "hard-coded strings" for statuslights and for TT remaining time in main screen.

Hope this second PR will be better than my first one...