### PR TITLE
Re-run calculateInsulin when OK is pressed

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/dialogs/WizardDialog.kt
@@ -114,6 +114,7 @@ class WizardDialog : DialogFragment() {
                 log.debug("guarding: ok already clicked")
             } else {
                 okClicked = true
+                calculateInsulin()
                 parentContext?.let { context ->
                     wizard?.confirmAndExecute(context)
                 }


### PR DESCRIPTION
This is to ensure that all changes are used. Previously notes field changes were missed where a change to a checkbox / insulin value where not edited after.

Could add another onchange event but seems safer to just always run calculateInsulin() before OK.

Should resolve #2164