### PR TITLE
Rounding: Use BigDemical for more accurate comparison

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/utils/Round.java
+++ b/app/src/main/java/info/nightscout/androidaps/utils/Round.java
@@ -1,14 +1,23 @@
 package info.nightscout.androidaps.utils;
 
+import java.math.BigDecimal;
+
 /**
  * Created by mike on 20.06.2016.
  */
 public class Round {
     public static Double roundTo(double x, Double step) {
-        if (x != 0d) {
-            return Math.round(x / step) * step;
+        if (x == 0d) {
+            return 0d;
         }
-        return 0d;
+
+        //Double oldCalc = Math.round(x / step) * step;
+        Double newCalc = BigDecimal.valueOf(Math.round(x / step)).multiply(BigDecimal.valueOf(step)).doubleValue();
+
+        // just for the tests, forcing failures
+        //newCalc = oldCalc;
+
+        return newCalc;
     }
     public static Double floorTo(Double x, Double step) {
         if (x != 0d) {

--- a/app/src/test/java/info/nightscout/androidaps/utils/RoundTest.java
+++ b/app/src/test/java/info/nightscout/androidaps/utils/RoundTest.java
@@ -12,9 +12,16 @@ public class RoundTest {
 
     @Test
     public void roundToTest() throws Exception {
-        assertEquals( 0.55d, Round.roundTo(0.54d, 0.05d), 0.00000001d );
-        assertEquals( 1d, Round.roundTo(1.49d, 1d), 0.00000001d );
-        assertEquals( 0d, Round.roundTo(0d, 1d), 0.00000001d );
+        assertEquals( 0.55d, Round.roundTo(0.54d, 0.05d), 0.00000000000000000001d );
+        assertEquals( -3.26d, Round.roundTo(-3.2553715764602713d, 0.01d), 0.00000000000000000001d );
+        assertEquals( 0.816d, Round.roundTo(0.8156666666666667d, 0.001d), 0.00000000000000000001d );
+        assertEquals( 0.235d, Round.roundTo(0.235d, 0.001d), 0.00000000000000000001d );
+        assertEquals( 0.3d, Round.roundTo(0.3d, 0.1d), 0.00000000000000001d );
+        assertEquals( 0.0017d, Round.roundTo(0.0016960652144170627d, 0.0001d), 0.00000000000000000001d );
+        assertEquals( 0.0078d, Round.roundTo(0.007804436682291013d, 0.0001d), 0.00000000000000000001d );
+        assertEquals( 0.6d, Round.roundTo(0.6d, 0.05d), 0.00000000000000000001d );
+        assertEquals( 1d, Round.roundTo(1.49d, 1d), 0.00000000000000000001d );
+        assertEquals( 0d, Round.roundTo(0d, 1d), 0.00000000000000000001d );
     }
 
     @Test


### PR DESCRIPTION
Change roundTo method to use BigDecimal rather than Double for more accurate results. Previously I had noticed that a 0.3u SMB was getting logged as 0.30000000000000004u which had a knock-on impact to xDrip.

Digging deeper I've seen lots of little rounding differences, hence having added several to the test cases - without this code change, they'd all fail. As such I left the commented lines in the Round class so people can easily test for themselves, but I'm happy to remove those lines if that's the project preference.

This is my first PR so I welcome any feedback!

![image](https://user-images.githubusercontent.com/3479092/68642813-6f929500-0563-11ea-99a0-87455e89db53.png)
