### PR TITLE
Deactivate Automation if Loop is disabled, not only if it is suspended

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/automation/AutomationPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/automation/AutomationPlugin.kt
@@ -161,7 +161,7 @@ object AutomationPlugin : PluginBase(PluginDescription()
     private fun processActions() {
         if (!isEnabled(PluginType.GENERAL))
             return
-        if (LoopPlugin.getPlugin().isSuspended) {
+        if (LoopPlugin.getPlugin().isSuspended || !LoopPlugin.getPlugin().isEnabled(PluginType.LOOP)) {
             if (L.isEnabled(L.AUTOMATION))
                 log.debug("Loop deactivated")
             return


### PR DESCRIPTION
Currently Automation is only deactivated if Loop is suspended for a temporary time (1h, 2h, 3h). 
Check also if Loop Plugin is disabled. (Loop deactivated in Overview)