### PR TITLE
ensure end of tbr doesn't override next tbr, closes #1963

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
@@ -898,7 +898,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
                 PreparedQuery<TemporaryBasal> preparedQuery2 = queryBuilder2.prepare();
                 List<TemporaryBasal> trList2 = getDaoTemporaryBasal().query(preparedQuery2);
 
-                if (trList2.size() > 0) {
+                if (trList2.size() > 0 && trList2.get(0).pumpId == 0) { // don't update existing record if it has a pumpId
                     old = trList2.get(0);
 
                     old.copyFromPump(tempBasal);
@@ -1001,7 +1001,8 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
         try {
             List<TemporaryBasal> tempbasals;
             QueryBuilder<TemporaryBasal, Long> queryBuilder = getDaoTemporaryBasal().queryBuilder();
-            queryBuilder.orderBy("date", ascending);
+            // order by date and duration to ensure end of previous tbr doesn't override next tbr
+            queryBuilder.orderBy("date", ascending).orderBy("durationInMinutes", ascending);
             Where where = queryBuilder.where();
             where.ge("date", mills);
             PreparedQuery<TemporaryBasal> preparedQuery = queryBuilder.prepare();
@@ -1017,7 +1018,8 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
         try {
             List<TemporaryBasal> tempbasals;
             QueryBuilder<TemporaryBasal, Long> queryBuilder = getDaoTemporaryBasal().queryBuilder();
-            queryBuilder.orderBy("date", ascending);
+            // order by date and duration to ensure end of previous tbr doesn't override next tbr
+            queryBuilder.orderBy("date", ascending).orderBy("durationInMinutes", ascending);
             Where where = queryBuilder.where();
             where.between("date", from, to);
             PreparedQuery<TemporaryBasal> preparedQuery = queryBuilder.prepare();

--- a/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
+++ b/app/src/main/java/info/nightscout/androidaps/db/DatabaseHelper.java
@@ -898,7 +898,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
                 PreparedQuery<TemporaryBasal> preparedQuery2 = queryBuilder2.prepare();
                 List<TemporaryBasal> trList2 = getDaoTemporaryBasal().query(preparedQuery2);
 
-                if (trList2.size() > 0 && trList2.get(0).pumpId == 0) { // don't update existing record if it has a pumpId
+                if (trList2.size() > 0) {
                     old = trList2.get(0);
 
                     old.copyFromPump(tempBasal);
@@ -1001,8 +1001,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
         try {
             List<TemporaryBasal> tempbasals;
             QueryBuilder<TemporaryBasal, Long> queryBuilder = getDaoTemporaryBasal().queryBuilder();
-            // order by date and duration to ensure end of previous tbr doesn't override next tbr
-            queryBuilder.orderBy("date", ascending).orderBy("durationInMinutes", ascending);
+            queryBuilder.orderBy("date", ascending);
             Where where = queryBuilder.where();
             where.ge("date", mills);
             PreparedQuery<TemporaryBasal> preparedQuery = queryBuilder.prepare();
@@ -1018,8 +1017,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
         try {
             List<TemporaryBasal> tempbasals;
             QueryBuilder<TemporaryBasal, Long> queryBuilder = getDaoTemporaryBasal().queryBuilder();
-            // order by date and duration to ensure end of previous tbr doesn't override next tbr
-            queryBuilder.orderBy("date", ascending).orderBy("durationInMinutes", ascending);
+            queryBuilder.orderBy("date", ascending);
             Where where = queryBuilder.where();
             where.between("date", from, to);
             PreparedQuery<TemporaryBasal> preparedQuery = queryBuilder.prepare();

--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
@@ -1301,7 +1301,8 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
 
     private void processStartOfTBREvent(String serial, List<TemporaryBasal> temporaryBasals, StartOfTBREvent event) {
         long timestamp = parseDate(event.getEventYear(), event.getEventMonth(), event.getEventDay(),
-                event.getEventHour(), event.getEventMinute(), event.getEventSecond()) + timeOffset;
+                event.getEventHour(), event.getEventMinute(), event.getEventSecond()) + timeOffset
+                + 500; // make the start of tbr half a second later, to ensure any end of tbr is processed/stored first
         InsightPumpID pumpID = new InsightPumpID();
         pumpID.eventID = event.getEventPosition();
         pumpID.pumpSerial = serial;
@@ -1320,7 +1321,8 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
 
     private void processEndOfTBREvent(String serial, List<TemporaryBasal> temporaryBasals, EndOfTBREvent event) {
         long timestamp = parseDate(event.getEventYear(), event.getEventMonth(), event.getEventDay(),
-                event.getEventHour(), event.getEventMinute(), event.getEventSecond()) + timeOffset;
+                event.getEventHour(), event.getEventMinute(), event.getEventSecond()) + timeOffset
+                - 500; // make the end of tbr half a second earlier, to ensure it's processed before the start of a new tbr at the same time
         InsightPumpID pumpID = new InsightPumpID();
         pumpID.eventID = event.getEventPosition();
         pumpID.pumpSerial = serial;

--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
@@ -1191,8 +1191,7 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
             temporaryBasal.isAbsolute = false;
             temporaryBasals.add(temporaryBasal);
         }
-        // order by date and duration to ensure end of previous tbr doesn't override next tbr
-        Collections.sort(temporaryBasals, (o1, o2) -> (int) (o1.date != o2.date ? (o1.date - o2.date) : (o1.durationInMinutes - o2.durationInMinutes)));
+        Collections.sort(temporaryBasals, (o1, o2) -> (int) (o1.date - o2.date));
         for (TemporaryBasal temporaryBasal : temporaryBasals)
             TreatmentsPlugin.getPlugin().addToHistoryTempBasal(temporaryBasal);
     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
@@ -1190,7 +1190,8 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
             temporaryBasal.isAbsolute = false;
             temporaryBasals.add(temporaryBasal);
         }
-        Collections.sort(temporaryBasals, (o1, o2) -> (int) (o1.date - o2.date));
+        // order by date and duration to ensure end of previous tbr doesn't override next tbr
+        Collections.sort(temporaryBasals, (o1, o2) -> (int) (o1.date != o2.date ? (o1.date - o2.date) : (o1.durationInMinutes - o2.durationInMinutes)));
         for (TemporaryBasal temporaryBasal : temporaryBasals)
             TreatmentsPlugin.getPlugin().addToHistoryTempBasal(temporaryBasal);
     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
@@ -346,6 +346,7 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
         calendar.set(Calendar.HOUR_OF_DAY, pumpTime.getHour());
         calendar.set(Calendar.MINUTE, pumpTime.getMinute());
         calendar.set(Calendar.SECOND, pumpTime.getSecond());
+        calendar.set(Calendar.MILLISECOND, 0); // truncate leftover milliseconds from current time
         if (calendar.get(Calendar.HOUR_OF_DAY) != pumpTime.getHour() || Math.abs(calendar.getTimeInMillis() - System.currentTimeMillis()) > 10000) {
             calendar.setTime(new Date());
             pumpTime.setYear(calendar.get(Calendar.YEAR));
@@ -1512,6 +1513,7 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
         calendar.set(Calendar.HOUR_OF_DAY, hour);
         calendar.set(Calendar.MINUTE, minute);
         calendar.set(Calendar.SECOND, second);
+        calendar.set(Calendar.MILLISECOND, 0); // truncate leftover milliseconds from current UTC time
         return calendar.getTimeInMillis();
     }
 
@@ -1541,6 +1543,7 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
         calendar.set(Calendar.HOUR_OF_DAY, relativeHour);
         calendar.set(Calendar.MINUTE, relativeMinute);
         calendar.set(Calendar.SECOND, relativeSecond);
+        calendar.set(Calendar.MILLISECOND, 0); // truncate leftover milliseconds from current UTC time
         return calendar.getTimeInMillis();
     }
 


### PR DESCRIPTION
I can see that @TebbeUbben has made changes (in another branch) to the way that end of TBRs are processed from Insight pumps, but I wanted this change in my dev branch to work around the bug for now.  I thought it may be useful for others that want the temporary fix too.

closes #1963