### PR TITLE
[FIX] For wear OS, fixes main menu item layout for long items

### DIFF
--- a/wear/src/main/res/layout-v26/list_item.xml
+++ b/wear/src/main/res/layout-v26/list_item.xml
@@ -1,0 +1,23 @@
+<info.nightscout.androidaps.interaction.utils.WearableListItemLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:gravity="center_vertical"
+    android:layout_width="match_parent"
+    android:layout_height="80dp">
+    <TextView
+        android:id="@+id/actionitem"
+        android:gravity="center_vertical|center_horizontal"
+        android:layout_width="match_parent"
+        android:layout_marginRight="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_height="match_parent"
+        android:fontFamily="sans-serif-condensed-light"
+        android:lineSpacingExtra="-4sp"
+        android:textColor="@color/dark_statusView"
+        android:textSize="32sp"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="12sp"
+        android:autoSizeMaxTextSize="32sp"
+        android:autoSizeStepGranularity="2sp"
+        />
+</info.nightscout.androidaps.interaction.utils.WearableListItemLayout>
+


### PR DESCRIPTION
When the label for the main menu item is too long (like in some translations) item was not visible 100%
![too-long-translation](https://user-images.githubusercontent.com/5094588/70525362-76eb9500-1b47-11ea-9d99-1ab001b7b3a2.png)
This fix allows text auto-sizing to fit the whole text of the label:
![fixed-layout](https://user-images.githubusercontent.com/5094588/70525395-8b2f9200-1b47-11ea-974a-64a8725136db.png)

Compatible with API 26+, which covers most of Wear OS watches and some of older Android Wear one.