### PR TITLE
Show profile even if it was switched with percentage

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/profile/ns/NSProfileFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/profile/ns/NSProfileFragment.kt
@@ -124,7 +124,10 @@ class NSProfileFragment : Fragment() {
             nsprofile_spinner.adapter = adapter
             // set selected to actual profile
             for (p in profileList.indices) {
-                if (profileList[p] == ProfileFunctions.getInstance().profileName)
+                val indexOfBrace = ProfileFunctions.getInstance().profileName.indexOf("(");
+                val concatedName = profileList[p].substring(0,indexOfBrace);
+
+                if (profileList[p] == concatedName)
                     nsprofile_spinner.setSelection(p)
             }
             profileview_noprofile.visibility = View.GONE


### PR DESCRIPTION
I have a percentage shifted profile and my NSProfile tab shows nothing until I select a profile manually. I added a simple check for "("
and the check to compare with the string before the opening braces