### PR TITLE
Steampunk watchface, add "Auto Granularity" option

### DIFF
--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/Steampunk.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/Steampunk.java
@@ -125,31 +125,48 @@ public class Steampunk extends BaseWatchFace {
         if (!rawData.sAvgDelta.equals("--")) {      //if a legitimate delta value is received, then...
             if (rawData.sAvgDelta.substring(0,1).equals("-")) deltaIsNegative = -1f;  //if the delta is negative, go counter-clockwise
             Float AbssAvgDelta = SafeParse.stringToFloat(rawData.sAvgDelta.substring(1)) ;   //get rid of the sign so it can be converted to float.
+            String autogranularity = "0" ;                                                   //autogranularity off
             //ensure the delta gauge is the right units and granularity
             if (!rawData.sUnits.equals("-")) {
                 if (rawData.sUnits.equals("mmol")) {
-                    if (sharedPrefs.getString("delta_granularity", "2").equals("1")) {  //low
+                    if (sharedPrefs.getString("delta_granularity", "2").equals("4")) {  //Auto granularity
+                        autogranularity = "1";                                                  // low (init)
+                        if (AbssAvgDelta < 0.3 ) {
+                            autogranularity = "3" ;                                             // high if below 0.3 mmol/l
+                        } else if (AbssAvgDelta < 0.5) {
+                            autogranularity = "2" ;                                             // medium if below 0.5 mmol/l
+                        }
+                    }
+                    if (sharedPrefs.getString("delta_granularity", "2").equals("1") || autogranularity.equals("1")) {  //low
                         mLinearLayout.setBackgroundResource(R.drawable.steampunk_gauge_mmol_10);
                         deltaRotationAngle = (AbssAvgDelta * 30f);
                     }
-                    if (sharedPrefs.getString("delta_granularity", "2").equals("2")) {  //medium
+                    if (sharedPrefs.getString("delta_granularity", "2").equals("2") || autogranularity.equals("2")) {  //medium
                         mLinearLayout.setBackgroundResource(R.drawable.steampunk_gauge_mmol_05);
                         deltaRotationAngle = (AbssAvgDelta * 60f);
                     }
-                    if (sharedPrefs.getString("delta_granularity", "2").equals("3")) {  //high
+                    if (sharedPrefs.getString("delta_granularity", "2").equals("3") || autogranularity.equals("3")) {  //high
                         mLinearLayout.setBackgroundResource(R.drawable.steampunk_gauge_mmol_03);
                         deltaRotationAngle = (AbssAvgDelta * 100f);
                     }
                 } else {
-                    if (sharedPrefs.getString("delta_granularity", "2").equals("1")) {  //low
+                    if (sharedPrefs.getString("delta_granularity", "2").equals("4")) {  //Auto granularity
+                        autogranularity = "1";                                                  // low (init)
+                        if (AbssAvgDelta < 5 ) {
+                            autogranularity = "3" ;                                             // high if below 5 mg/dl
+                        } else if (AbssAvgDelta < 10) {
+                            autogranularity = "2" ;                                             // medium if below 10 mg/dl
+                        }
+                    }
+                    if (sharedPrefs.getString("delta_granularity", "2").equals("1") || autogranularity.equals("1")) {  //low
                         mLinearLayout.setBackgroundResource(R.drawable.steampunk_gauge_mgdl_20);
                         deltaRotationAngle = (AbssAvgDelta * 1.5f);
                     }
-                    if (sharedPrefs.getString("delta_granularity", "2").equals("2")) {  //medium
+                    if (sharedPrefs.getString("delta_granularity", "2").equals("2") || autogranularity.equals("2")) {  //medium
                         mLinearLayout.setBackgroundResource(R.drawable.steampunk_gauge_mgdl_10);
                         deltaRotationAngle = (AbssAvgDelta * 3f);
                     }
-                    if (sharedPrefs.getString("delta_granularity", "2").equals("3")) {  //high
+                    if (sharedPrefs.getString("delta_granularity", "2").equals("3") || autogranularity.equals("3")) {  //high
                         mLinearLayout.setBackgroundResource(R.drawable.steampunk_gauge_mgdl_5);
                         deltaRotationAngle = (AbssAvgDelta * 6f);
                     }

--- a/wear/src/main/res/values/arrays.xml
+++ b/wear/src/main/res/values/arrays.xml
@@ -21,12 +21,14 @@
         <item>@string/pref_low</item>
         <item>@string/pref_medium</item>
         <item>@string/pref_high</item>
+        <item>@string/pref_auto</item>
     </string-array>
 
     <string-array name="delta_granularity_values">
         <item>1</item>
         <item>2</item>
         <item>3</item>
+        <item>4</item>
     </string-array>
 
     <string-array name="input_design">

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="pref_low">Low</string>
     <string name="pref_medium">Medium</string>
     <string name="pref_high">High</string>
+    <string name="pref_auto">Auto</string>
     <string name="pref_big_numbers">Big Numbers</string>
     <string name="pref_ring_history">Ring History</string>
     <string name="pref_light_ring_history">Light Ring History</string>


### PR DESCRIPTION
Add a fourth option ("Auto" for "Automatic granularity") for steampunk watchface.
=> It adjust granularity in watchface according to average delta value

Tested on my watch (setting mg/dl) and ok (not tested  with mmol/l)