### PR TITLE
OpenAPS SMB: max SMB minutes: restrict to valid inputs.

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -200,6 +200,16 @@
         <item>@string/key_medtronic_pump_battery_nizn</item>
     </string-array>
 
+    <string-array name="smbMaxMinutes">
+        <item>15</item>
+        <item>30</item>
+        <item>45</item>
+        <item>60</item>
+        <item>75</item>
+        <item>90</item>
+        <item>105</item>
+        <item>120</item>
+    </string-array>
 
     key_medtronic_bolus_debug
 

--- a/app/src/main/res/xml/pref_openapssmb.xml
+++ b/app/src/main/res/xml/pref_openapssmb.xml
@@ -65,19 +65,12 @@
             android:summary="@string/enablesmbaftercarbs_summary"
             android:title="@string/enablesmbaftercarbs" />
 
-        <com.andreabaccega.widget.ValidatingEditTextPreference
+        <ListPreference
             android:defaultValue="30"
-            android:dialogMessage="@string/smbmaxminutes"
-            android:digits="0123456789"
-            android:inputType="number"
+            android:entries="@array/smbMaxMinutes"
+            android:entryValues="@array/smbMaxMinutes"
             android:key="@string/key_smbmaxminutes"
-            android:maxLines="20"
-            android:selectAllOnFocus="true"
-            android:singleLine="true"
-            android:title="@string/smbmaxminutes_summary"
-            validate:maxNumber="120"
-            validate:minNumber="15"
-            validate:testType="numericRange" />
+            android:title="@string/smbmaxminutes_summary" />
 
         <SwitchPreference
             android:defaultValue="false"


### PR DESCRIPTION
Small UX improvement.
Tested to work with existing prefs (no type change, so not an issue).

![Screenshot_1576182169](https://user-images.githubusercontent.com/1732305/70749825-698fff80-1d2d-11ea-87ba-f6e9b1bcb745.png)
