### PR TITLE
Watchface improvements : (Direct actions, color and text size)

### DIFF
--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/BgGraphBuilder.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/BgGraphBuilder.java
@@ -213,10 +213,10 @@ public class BgGraphBuilder {
 
         addPredictionLines(lines);
         lines.add(basalLine((float) minChart, factor, highlight));
-        lines.add(bolusLine((float) minChart));
         lines.add(bolusInvalidLine((float) minChart));
         lines.add(carbsLine((float) minChart));
         lines.add(smbLine((float) minChart));
+        lines.add(bolusLine((float) minChart));                                                                     // Bolus line shifted in front of Carb line
 
         return lines;
     }
@@ -249,7 +249,7 @@ public class BgGraphBuilder {
 
         for (BolusWatchData bwd: bolusWatchDataList) {
             if(bwd.date > start_time && bwd.date <= end_time && !bwd.isSMB && bwd.isValid && bwd.bolus > 0) {
-                pointValues.add(new PointValue(fuzz(bwd.date), (float) offset-2));
+                pointValues.add(new PointValue(fuzz(bwd.date), (float) offset-4*pointSize));                    // Down offset of bolus line increased
             }
         }
         Line line = new Line(pointValues);

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/Cockpit.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/Cockpit.java
@@ -10,11 +10,13 @@ import info.nightscout.androidaps.interaction.menus.MainMenuActivity;
 
 /**
  * Created by andrew-warrington on 18/11/2017.
+ * Updated by Philoul on dec 2019(onTapCommand)
  */
 
 public class Cockpit extends BaseWatchFace {
 
-    private long sgvTapTime = 0;
+    private long TapTime = 0;
+    private WatchfaceZone LastZone = WatchfaceZone.NONE;
 
     @Override
     public void onCreate() {
@@ -26,14 +28,40 @@ public class Cockpit extends BaseWatchFace {
 
     @Override
     protected void onTapCommand(int tapType, int x, int y, long eventTime) {
+        if (tapType == TAP_TYPE_TAP) {
+            WatchfaceZone TapZone ;
+            int xlow = mRelativeLayout.getWidth()/3;
+            int ylow = mRelativeLayout.getHeight()/3;
 
-        if (tapType == TAP_TYPE_TAP ) {
-            if (eventTime - sgvTapTime < 800) {
-                Intent intent = new Intent(this, MainMenuActivity.class);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                startActivity(intent);
+            if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y >= 2*ylow) {                                  // if double tap on DOWN
+                TapZone = WatchfaceZone.DOWN;
+            } else if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y <= ylow) {                                    // if double tap on TOP
+                TapZone = WatchfaceZone.TOP;
+            } else if (x <= xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on LEFT
+                TapZone = WatchfaceZone.LEFT;
+            } else if (x >= 2*xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on RIGHT
+                TapZone = WatchfaceZone.RIGHT;
+            } else if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on CENTER
+                TapZone = WatchfaceZone.CENTER;
+            } else {                                                // on all background (outside chart and Top, Down, left, right and center) access to main menu
+                TapZone = WatchfaceZone.BACKGROUND;
             }
-            sgvTapTime = eventTime;
+            if (eventTime - TapTime < 800 && LastZone == TapZone) {
+                doTapAction(TapZone);
+            }
+            TapTime = eventTime;
+            LastZone = TapZone;
         }
     }
 

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/Home.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/Home.java
@@ -13,8 +13,8 @@ import info.nightscout.androidaps.interaction.menus.MainMenuActivity;
 
 public class Home extends BaseWatchFace {
 
-    private long chartTapTime = 0;
-    private long sgvTapTime = 0;
+    private long TapTime = 0;
+    private WatchfaceZone LastZone = WatchfaceZone.NONE;
 
     @Override
     public void onCreate() {
@@ -26,37 +26,46 @@ public class Home extends BaseWatchFace {
 
     @Override
     protected void onTapCommand(int tapType, int x, int y, long eventTime) {
+        if (tapType == TAP_TYPE_TAP) {
+            WatchfaceZone TapZone ;
+            int xlow = mRelativeLayout.getWidth()/3;
+            int ylow = chart.getTop()/2;
 
-        int extra = mSgv!=null?(mSgv.getRight() - mSgv.getLeft())/2:0;
-
-        if (tapType == TAP_TYPE_TAP&&
-                x >=chart.getLeft() &&
-                x <= chart.getRight()&&
-                y >= chart.getTop() &&
-                y <= chart.getBottom()){
-            if (eventTime - chartTapTime < 800){
-                changeChartTimeframe();
+            if (x >= chart.getLeft() &&
+                    x <= chart.getRight() &&
+                    y >= chart.getTop() &&
+                    y <= chart.getBottom()) {                       // if double tap in chart
+                TapZone = WatchfaceZone.CHART;
+            } else if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y <= ylow) {                                    // if double tap on TOP
+                TapZone = WatchfaceZone.TOP;
+            } else if (x <= xlow &&
+                    y >= ylow) {                                    // if double tap on LEFT
+                TapZone = WatchfaceZone.LEFT;
+            } else if (x >= 2*xlow &&
+                    y >= ylow) {                                    // if double tap on RIGHT
+                TapZone = WatchfaceZone.RIGHT;
+            } else if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on CENTER
+                TapZone = WatchfaceZone.CENTER;
+            } else if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y >= 2*ylow) {                                    // if double tap on DOWN (below chart)
+                TapZone = WatchfaceZone.DOWN;
+            } else {                                                // on all background (outside chart and Top, Down, left, right and center) access to main menu
+                TapZone = WatchfaceZone.BACKGROUND;
             }
-            chartTapTime = eventTime;
-        } else if (tapType == TAP_TYPE_TAP&&
-                x + extra >=mSgv.getLeft() &&
-                x - extra <= mSgv.getRight()&&
-                y >= mSgv.getTop() &&
-                y <= mSgv.getBottom()){
-            if (eventTime - sgvTapTime < 800){
-                Intent intent = new Intent(this, MainMenuActivity.class);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                startActivity(intent);
+            if (eventTime - TapTime < 800 && LastZone == TapZone) {
+                doTapAction(TapZone);
             }
-            sgvTapTime = eventTime;
+            TapTime = eventTime;
+            LastZone = TapZone;
         }
     }
 
-    private void changeChartTimeframe() {
-        int timeframe = Integer.parseInt(sharedPrefs.getString("chart_timeframe", "3"));
-        timeframe = (timeframe%5) + 1;
-        sharedPrefs.edit().putString("chart_timeframe", "" + timeframe).commit();
-    }
 
     @Override
     protected WatchFaceStyle getWatchFaceStyle(){
@@ -85,20 +94,20 @@ public class Home extends BaseWatchFace {
 
         if (ageLevel == 1) {
             mTimestamp.setTextColor(ContextCompat.getColor(getApplicationContext(), dividerMatchesBg ?
-                    R.color.dark_midColor : R.color.dark_mTimestamp1_home));
+                    R.color.dark_gridColor : R.color.dark_mTimestamp1_home));
         } else {
             mTimestamp.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_TimestampOld));
         }
 
         if (rawData.batteryLevel == 1) {
             mUploaderBattery.setTextColor(ContextCompat.getColor(getApplicationContext(), dividerMatchesBg ?
-                    R.color.dark_midColor : R.color.dark_uploaderBattery));
+                    R.color.dark_gridColor : R.color.dark_uploaderBattery));
         } else {
             mUploaderBattery.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_uploaderBatteryEmpty));
         }
 
         mStatus.setTextColor(ContextCompat.getColor(getApplicationContext(), dividerMatchesBg ?
-                R.color.dark_midColor : R.color.dark_mStatus_home));
+                R.color.dark_gridColor : R.color.dark_mStatus_home));
 
         if (chart != null) {
             highColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_highColor);
@@ -115,13 +124,13 @@ public class Home extends BaseWatchFace {
     protected void setColorLowRes() {
         mTime.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
         mRelativeLayout.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_background));
-        mSgv.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mDelta.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
+        mSgv.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor));
+        mDelta.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor));
         mTimestamp.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_Timestamp));
         if (chart != null) {
-            highColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor);
-            lowColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor);
-            midColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor);
+            highColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor);
+            lowColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor);
+            midColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor);
             gridColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor);
             basalBackgroundColor = ContextCompat.getColor(getApplicationContext(), R.color.basal_dark_lowres);
             basalCenterColor = ContextCompat.getColor(getApplicationContext(), R.color.basal_light_lowres);

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/Home2.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/Home2.java
@@ -32,8 +32,8 @@ public class Home2 extends BaseWatchFace {
 
             if (x >= chart.getLeft() &&
                     x <= chart.getRight() &&
-                    y >= chart.getTop() &&                          // todo reduce a little bie chart size to keep a little more space for DOWN ZONE
-                    y <= chart.getBottom()) {                       // if double tap in chart
+                    y >= chart.getTop() &&                           // 85% of chart height to leave some space for DOWN ZONE
+                    y <= (chart.getTop() + 0.85 * chart.getHeight())) {                       // if double tap in chart
                 TapZone = WatchfaceZone.CHART;
             } else if (x >= xlow &&
                     x  <= 2*xlow &&
@@ -257,11 +257,11 @@ public class Home2 extends BaseWatchFace {
 
     protected void setTextSizes() {
         // Adjust text size according to watchscreen resolution
-        double hoursize = mRelativeLayout.getHeight()/9.5;  // 42 for 400, 34 for 320 , 29 for 280 (original = 30)
-        int svgsize = mRelativeLayout.getHeight()/8;        // 50 for 400, 40 for 320 , 35 for 280 (original = 38)
-        int smalltxt = mRelativeLayout.getHeight()/32;      // 13 for 400, 10 for 320 , 9 for 280 (original = 10)
-        int midtxt = mRelativeLayout.getHeight()/25;        // 16 for 400, 13 for 320 , 11 for 280 (original = 14)
-        int topmargin = mRelativeLayout.getHeight()>320 ? (320 - mRelativeLayout.getHeight())/10 : 0;   // top margin for hour needs to be adjust above 320px
+        int hoursize = mRelativeLayout.getHeight()/9.5 > 30 ? (int)(mRelativeLayout.getHeight()/9.5) : 30;  // 42 for 400, 34 for 320 , 29 for 280 (original = 30)
+        int svgsize = mRelativeLayout.getHeight()/8 > 38 ? mRelativeLayout.getHeight()/8 : 38;              // 50 for 400, 40 for 320 , 35 for 280 (original = 38)
+        int smalltxt = mRelativeLayout.getHeight()/32 > 10 ? mRelativeLayout.getHeight()/32 : 10;           // 13 for 400, 10 for 320 , 9 for 280 (original = 10)
+        int midtxt = mRelativeLayout.getHeight()/25 > 14 ? mRelativeLayout.getHeight()/25 : 14;             // 16 for 400, 13 for 320 , 11 for 280 (original = 14)
+        int topmargin = mRelativeLayout.getHeight()>320 ? (320 - mRelativeLayout.getHeight())/10 : 0;       // top margin for hour needs to be adjust above 320px
         LinearLayout.LayoutParams params = (LinearLayout.LayoutParams)mTime.getLayoutParams();
         if (mIOB1 != null && mIOB2 != null) {
             if (rawData.detailedIOB) {

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/Home2.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/Home2.java
@@ -1,21 +1,18 @@
 package info.nightscout.androidaps.watchfaces;
 
-import android.content.Intent;
 import android.graphics.Color;
 import androidx.annotation.ColorInt;
 import androidx.core.content.ContextCompat;
 import android.support.wearable.watchface.WatchFaceStyle;
 import android.view.LayoutInflater;
-
+import android.widget.LinearLayout;
 import com.ustwo.clockwise.common.WatchMode;
 
 import info.nightscout.androidaps.R;
-import info.nightscout.androidaps.interaction.menus.MainMenuActivity;
 
 public class Home2 extends BaseWatchFace {
-
-    private long chartTapTime = 0;
-    private long sgvTapTime = 0;
+    private long TapTime = 0;
+    private WatchfaceZone LastZone = WatchfaceZone.NONE;
 
     @Override
     public void onCreate() {
@@ -28,36 +25,48 @@ public class Home2 extends BaseWatchFace {
     @Override
     protected void onTapCommand(int tapType, int x, int y, long eventTime) {
 
-        int extra = mSgv!=null?(mSgv.getRight() - mSgv.getLeft())/2:0;
+        if (tapType == TAP_TYPE_TAP) {
+            WatchfaceZone TapZone ;
+            int xlow = mRelativeLayout.getWidth()/3;
+            int ylow = chart.getTop()/2;
 
-        if (tapType == TAP_TYPE_TAP&&
-                x >=chart.getLeft() &&
-                x <= chart.getRight()&&
-                y >= chart.getTop() &&
-                y <= chart.getBottom()){
-            if (eventTime - chartTapTime < 800){
-                changeChartTimeframe();
+            if (x >= chart.getLeft() &&
+                    x <= chart.getRight() &&
+                    y >= chart.getTop() &&                          // todo reduce a little bie chart size to keep a little more space for DOWN ZONE
+                    y <= chart.getBottom()) {                       // if double tap in chart
+                TapZone = WatchfaceZone.CHART;
+            } else if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y <= ylow) {                                    // if double tap on TOP
+                TapZone = WatchfaceZone.TOP;
+            } else if (x <= xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on LEFT
+                TapZone = WatchfaceZone.LEFT;
+            } else if (x >= 2*xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on RIGHT
+                TapZone = WatchfaceZone.RIGHT;
+            } else if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on CENTER
+                TapZone = WatchfaceZone.CENTER;
+            } else if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y >= 2*ylow) {                                  // // if double tap on DOWN (below chart)
+                TapZone = WatchfaceZone.DOWN;
+            } else {                                                // on all background (outside chart and Top, Down, left, right and center) access to main menu
+                TapZone = WatchfaceZone.BACKGROUND;
             }
-            chartTapTime = eventTime;
-        } else if (tapType == TAP_TYPE_TAP&&
-                x + extra >=mSgv.getLeft() &&
-                x - extra <= mSgv.getRight()&&
-                y >= mSgv.getTop() &&
-                y <= mSgv.getBottom()){
-            if (eventTime - sgvTapTime < 800){
-                Intent intent = new Intent(this, MainMenuActivity.class);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                startActivity(intent);
+            if (eventTime - TapTime < 800 && LastZone == TapZone) {
+                doTapAction(TapZone);
             }
-            sgvTapTime = eventTime;
+            TapTime = eventTime;
+            LastZone = TapZone;
         }
     }
 
-    private void changeChartTimeframe() {
-        int timeframe = Integer.parseInt(sharedPrefs.getString("chart_timeframe", "3"));
-        timeframe = (timeframe%5) + 1;
-        sharedPrefs.edit().putString("chart_timeframe", "" + timeframe).commit();
-    }
 
     @Override
     protected WatchFaceStyle getWatchFaceStyle(){
@@ -66,23 +75,23 @@ public class Home2 extends BaseWatchFace {
 
     protected void setColorDark() {
         @ColorInt final int dividerTxtColor = dividerMatchesBg ?
-                ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor) : Color.BLACK;
+                ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor) : Color.BLACK;
         @ColorInt final int dividerBatteryOkColor = ContextCompat.getColor(getApplicationContext(),
-                dividerMatchesBg ? R.color.dark_midColor : R.color.dark_uploaderBattery);
+                dividerMatchesBg ? R.color.dark_gridColor : R.color.dark_uploaderBattery);
         @ColorInt final int dividerBgColor = ContextCompat.getColor(getApplicationContext(),
                 dividerMatchesBg ? R.color.dark_background : R.color.dark_statusView);
 
         mLinearLayout.setBackgroundColor(dividerBgColor);
         mLinearLayout2.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_background));
         mRelativeLayout.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_background));
-        mTime.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mIOB1.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mIOB2.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mCOB1.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mCOB2.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mDay.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mMonth.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mLoop.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
+        mTime.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
+        mIOB1.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.grey_300));
+        mIOB2.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.grey_300));
+        mCOB1.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.grey_300));
+        mCOB2.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.grey_300));
+        mDay.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
+        mMonth.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
+        mLoop.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
 
         setTextSizes();
 
@@ -98,7 +107,7 @@ public class Home2 extends BaseWatchFace {
         }
 
         if (ageLevel == 1) {
-            mTimestamp.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
+            mTimestamp.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
         } else {
             mTimestamp.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_TimestampOld));
         }
@@ -127,6 +136,7 @@ public class Home2 extends BaseWatchFace {
             gridColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor);
             basalBackgroundColor = ContextCompat.getColor(getApplicationContext(), R.color.basal_dark);
             basalCenterColor = ContextCompat.getColor(getApplicationContext(), R.color.basal_light);
+            carbColor =  ContextCompat.getColor(getApplicationContext(), R.color.dark_carbcolor);
             pointSize = 2;
             setupCharts();
         }
@@ -134,7 +144,7 @@ public class Home2 extends BaseWatchFace {
 
     protected void setColorLowRes() {
         @ColorInt final int dividerTxtColor = dividerMatchesBg ?
-                ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor) : Color.BLACK;
+                ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor) : Color.BLACK;
         @ColorInt final int dividerBgColor = ContextCompat.getColor(getApplicationContext(),
                 dividerMatchesBg ? R.color.dark_background : R.color.dark_statusView);
 
@@ -142,9 +152,9 @@ public class Home2 extends BaseWatchFace {
         mLinearLayout2.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_background));
         mRelativeLayout.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_background));
         mLoop.setBackgroundResource(R.drawable.loop_grey_25);
-        mLoop.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mSgv.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mDirection.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
+        mLoop.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
+        mSgv.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
+        mDirection.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
         mTimestamp.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_Timestamp));
         mDelta.setTextColor(dividerTxtColor);
         mAvgDelta.setTextColor(dividerTxtColor);
@@ -152,17 +162,17 @@ public class Home2 extends BaseWatchFace {
         mUploaderBattery.setTextColor(dividerTxtColor);
         mBasalRate.setTextColor(dividerTxtColor);
         mBgi.setTextColor(dividerTxtColor);
-        mIOB1.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mIOB2.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mCOB1.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mCOB2.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mDay.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
-        mMonth.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
+        mIOB1.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
+        mIOB2.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
+        mCOB1.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
+        mCOB2.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
+        mDay.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
+        mMonth.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
         mTime.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_mTime));
         if (chart != null) {
-            highColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor);
-            lowColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor);
-            midColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor);
+            highColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor);
+            lowColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor);
+            midColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor);
             gridColor = ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor);
             basalBackgroundColor = ContextCompat.getColor(getApplicationContext(), R.color.basal_dark_lowres);
             basalCenterColor = ContextCompat.getColor(getApplicationContext(), R.color.basal_light_lowres);
@@ -177,7 +187,7 @@ public class Home2 extends BaseWatchFace {
         if (getCurrentWatchMode() == WatchMode.INTERACTIVE) {
 
             @ColorInt final int dividerTxtColor = dividerMatchesBg ?  Color.BLACK :
-                    ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor);
+                    ContextCompat.getColor(getApplicationContext(), R.color.dark_gridColor);
             @ColorInt final int dividerBgColor = ContextCompat.getColor(getApplicationContext(),
                     dividerMatchesBg ? R.color.light_background : R.color.light_stripe_background);
 
@@ -185,10 +195,10 @@ public class Home2 extends BaseWatchFace {
             mLinearLayout2.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.light_background));
             mRelativeLayout.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.light_background));
             mTime.setTextColor(Color.BLACK);
-            mIOB1.setTextColor(Color.BLACK);
-            mIOB2.setTextColor(Color.BLACK);
-            mCOB1.setTextColor(Color.BLACK);
-            mCOB2.setTextColor(Color.BLACK);
+            mIOB1.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.grey_steampunk));
+            mIOB2.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.grey_steampunk));
+            mCOB1.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.grey_steampunk));
+            mCOB2.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.grey_steampunk));
             mDay.setTextColor(Color.BLACK);
             mMonth.setTextColor(Color.BLACK);
             mLoop.setTextColor(Color.BLACK);
@@ -236,6 +246,7 @@ public class Home2 extends BaseWatchFace {
                 gridColor = ContextCompat.getColor(getApplicationContext(), R.color.light_gridColor);
                 basalBackgroundColor = ContextCompat.getColor(getApplicationContext(), R.color.basal_light);
                 basalCenterColor = ContextCompat.getColor(getApplicationContext(), R.color.basal_dark);
+                carbColor =  ContextCompat.getColor(getApplicationContext(), R.color.light_carbcolor);
                 pointSize = 2;
                 setupCharts();
             }
@@ -245,16 +256,29 @@ public class Home2 extends BaseWatchFace {
     }
 
     protected void setTextSizes() {
-
+        // Adjust text size according to watchscreen resolution
+        double hoursize = mRelativeLayout.getHeight()/9.5;  // 42 for 400, 34 for 320 , 29 for 280 (original = 30)
+        int svgsize = mRelativeLayout.getHeight()/8;        // 50 for 400, 40 for 320 , 35 for 280 (original = 38)
+        int smalltxt = mRelativeLayout.getHeight()/32;      // 13 for 400, 10 for 320 , 9 for 280 (original = 10)
+        int midtxt = mRelativeLayout.getHeight()/25;        // 16 for 400, 13 for 320 , 11 for 280 (original = 14)
+        int topmargin = mRelativeLayout.getHeight()>320 ? (320 - mRelativeLayout.getHeight())/10 : 0;   // top margin for hour needs to be adjust above 320px
+        LinearLayout.LayoutParams params = (LinearLayout.LayoutParams)mTime.getLayoutParams();
         if (mIOB1 != null && mIOB2 != null) {
-
             if (rawData.detailedIOB) {
-                mIOB1.setTextSize(14);
-                mIOB2.setTextSize(10);
+                mIOB1.setTextSize(midtxt);
+                mIOB2.setTextSize(smalltxt);
             } else {
-                mIOB1.setTextSize(10);
-                mIOB2.setTextSize(14);
+                mIOB1.setTextSize(smalltxt);
+                mIOB2.setTextSize(midtxt);
             }
         }
+        mCOB1.setTextSize(smalltxt);
+        mCOB2.setTextSize(midtxt);
+        mDay.setTextSize(midtxt);
+        mMonth.setTextSize(smalltxt);
+        mTime.setTextSize((int) hoursize);
+        params.setMargins(0, topmargin, 0, 0); //substitute parameters for left, top, right, bottom
+        mTime.setLayoutParams(params);
+        mSgv.setTextSize(svgsize);
     }
 }

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/LargeHome.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/LargeHome.java
@@ -13,7 +13,8 @@ import info.nightscout.androidaps.interaction.menus.MainMenuActivity;
 
 public class LargeHome extends BaseWatchFace {
 
-    private long sgvTapTime = 0;
+    private long TapTime = 0;
+    private WatchfaceZone LastZone = WatchfaceZone.NONE;
 
     @Override
     public void onCreate() {
@@ -25,20 +26,40 @@ public class LargeHome extends BaseWatchFace {
 
     @Override
     protected void onTapCommand(int tapType, int x, int y, long eventTime) {
+        if (tapType == TAP_TYPE_TAP) {
+            WatchfaceZone TapZone ;
+            int xlow = mRelativeLayout.getWidth()/3;
+            int ylow = mRelativeLayout.getHeight()/3;
 
-        int extra = mSgv!=null?(mSgv.getRight() - mSgv.getLeft())/2:0;
-
-        if (tapType == TAP_TYPE_TAP&&
-                x + extra >=mSgv.getLeft() &&
-                x - extra <= mSgv.getRight()&&
-                y >= mSgv.getTop() &&
-                y <= mSgv.getBottom()){
-            if (eventTime - sgvTapTime < 800){
-                Intent intent = new Intent(this, MainMenuActivity.class);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                startActivity(intent);
+            if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y >= 2*ylow) {                                  // if double tap on DOWN
+                TapZone = WatchfaceZone.DOWN;
+            } else if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y <= ylow) {                                    // if double tap on TOP
+                TapZone = WatchfaceZone.TOP;
+            } else if (x <= xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on LEFT
+                TapZone = WatchfaceZone.LEFT;
+            } else if (x >= 2*xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on RIGHT
+                TapZone = WatchfaceZone.RIGHT;
+            } else if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on CENTER
+                TapZone = WatchfaceZone.CENTER;
+            } else {                                                // on all background (outside chart and Top, Down, left, right and center) access to main menu
+                TapZone = WatchfaceZone.BACKGROUND;
             }
-            sgvTapTime = eventTime;
+            if (eventTime - TapTime < 800 && LastZone == TapZone) {
+                doTapAction(TapZone);
+            }
+            TapTime = eventTime;
+            LastZone = TapZone;
         }
     }
 

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/NOChart.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/NOChart.java
@@ -41,11 +41,17 @@ import com.ustwo.clockwise.wearable.WatchFace;
 import java.util.ArrayList;
 
 import info.nightscout.androidaps.R;
+import info.nightscout.androidaps.aaps;
 import info.nightscout.androidaps.data.BasalWatchData;
 import info.nightscout.androidaps.data.BgWatchData;
 import info.nightscout.androidaps.data.ListenerService;
 import info.nightscout.androidaps.data.TempWatchData;
+import info.nightscout.androidaps.interaction.actions.BolusActivity;
+import info.nightscout.androidaps.interaction.actions.ECarbActivity;
+import info.nightscout.androidaps.interaction.actions.TempTargetActivity;
+import info.nightscout.androidaps.interaction.actions.WizardActivity;
 import info.nightscout.androidaps.interaction.menus.MainMenuActivity;
+import info.nightscout.androidaps.interaction.menus.StatusMenuActivity;
 
 /**
  * Created by adrianLxM.
@@ -78,7 +84,8 @@ public class NOChart extends WatchFace implements SharedPreferences.OnSharedPref
     private String sgvString = "--";
     private String externalStatusString = "no status";
     private TextView statusView;
-    private long sgvTapTime = 0l;
+    private long TapTime = 0;
+    private WatchfaceZone LastZone = WatchfaceZone.NONE;
 
     @Override
     public void onCreate() {
@@ -143,20 +150,148 @@ public class NOChart extends WatchFace implements SharedPreferences.OnSharedPref
 
     @Override
     protected void onTapCommand(int tapType, int x, int y, long eventTime) {
+        if (tapType == TAP_TYPE_TAP) {
+            RelativeLayout mRelativeLayout = (RelativeLayout) layoutView.findViewById(R.id.main_layout);
+            WatchfaceZone TapZone;
+            int xlow = mRelativeLayout.getWidth()/3;
+            int ylow = mRelativeLayout.getHeight()/3;
 
-        int extra = mSgv!=null?(mSgv.getRight() - mSgv.getLeft())/2:0;
+            if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y >= 2*ylow) {                                  // if double tap on Down
+                TapZone = WatchfaceZone.DOWN;
+            } else if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y <= ylow) {                                    // if double tap on TOP
+                TapZone = WatchfaceZone.TOP;
+            } else if (x <= xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on LEFT
+                TapZone = WatchfaceZone.LEFT;
+            } else if (x >= 2*xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on RIGHT
+                TapZone = WatchfaceZone.RIGHT;
+            } else if (x >= xlow &&
+                    x  <= 2*xlow &&
+                    y >= ylow &&
+                    y <= 2*ylow) {                                    // if double tap on CENTER
+                TapZone = WatchfaceZone.CENTER;
+            } else {                                                // on all background (outside chart and Top, Down, left, right and center) access to main menu
+                TapZone = WatchfaceZone.BACKGROUND;
+            }
+            if (eventTime - TapTime < 800 && LastZone == TapZone) {
+                doTapAction(TapZone);
+            }
+            TapTime = eventTime;
+            LastZone = TapZone;
+        }
+    }
 
-        if (tapType == TAP_TYPE_TAP&&
-                x + extra >=mSgv.getLeft() &&
-                x - extra <= mSgv.getRight()&&
-                y >= mSgv.getTop() &&
-                y <= mSgv.getBottom()){
-            if (eventTime - sgvTapTime < 800){
-                Intent intent = new Intent(this, MainMenuActivity.class);
+    private void doTapAction(WatchfaceZone zone) {
+        switch (zone) {
+            case BACKGROUND:
+                doAction(WatchfaceAction.MENU);
+                break;
+            case TOP:
+                doAction(remapActionWithUserPreferences(sharedPrefs.getString("action_top", "none")));
+                break;
+            case DOWN:
+                doAction(remapActionWithUserPreferences(sharedPrefs.getString("action_down", "none")));
+                break;
+            case LEFT:
+                doAction(remapActionWithUserPreferences(sharedPrefs.getString("action_left", "none")));
+                break;
+            case RIGHT:
+                doAction(remapActionWithUserPreferences(sharedPrefs.getString("action_right", "none")));
+                break;
+            case CENTER:
+                doAction(remapActionWithUserPreferences(sharedPrefs.getString("action_center", "none")));
+                break;
+            default:
+                // no action
+        }
+    }
+
+
+
+    private void doAction(WatchfaceAction action) {
+        Intent intent = null;
+
+        switch (action) {
+            case TEMPT:
+                intent = new Intent(this, TempTargetActivity.class);
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 startActivity(intent);
-            }
-            sgvTapTime = eventTime;
+                break;
+            case WIZARD:
+                intent = new Intent(aaps.getAppContext(), WizardActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(intent);
+                break;
+            case BOLUS:
+                intent = new Intent(aaps.getAppContext(), BolusActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(intent);
+                break;
+            case ECARB:
+                intent = new Intent(aaps.getAppContext(), ECarbActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(intent);
+                break;
+            case STATUS:
+                intent = new Intent(aaps.getAppContext(), StatusMenuActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(intent);
+                break;
+            case CPP:
+                ListenerService.initiateAction(this, "opencpp");
+                break;
+            case TDD:
+                ListenerService.initiateAction(this, "tddstats");
+                break;
+            case LOOP:
+                ListenerService.initiateAction(this, "status loop");
+                break;
+            case PUMP:
+                ListenerService.initiateAction(this, "status pump");
+                break;
+            case MENU:
+                intent = new Intent(aaps.getAppContext(), MainMenuActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(intent);
+                break;
+            case NONE:
+            default:
+                // do nothing
+        }
+    }
+
+    private WatchfaceAction remapActionWithUserPreferences(String userPrefAction) {
+        switch (userPrefAction) {
+            case "tempt":
+                return WatchfaceAction.TEMPT;
+            case "wizard":
+                return WatchfaceAction.WIZARD;
+            case "bolus":
+                return WatchfaceAction.BOLUS;
+            case "ecarb":
+                return WatchfaceAction.ECARB;
+            case "status":
+                return WatchfaceAction.STATUS;
+            case "pump":
+                return WatchfaceAction.PUMP;
+            case "loop":
+                return WatchfaceAction.LOOP;
+            case "cpp":
+                return WatchfaceAction.CPP;
+            case "tdd":
+                return WatchfaceAction.TDD;
+            case "none":
+                return WatchfaceAction.NONE;
+            case "menu":
+            default:
+                return WatchfaceAction.MENU;
         }
     }
 

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/WatchfaceAction.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/WatchfaceAction.java
@@ -1,0 +1,16 @@
+package info.nightscout.androidaps.watchfaces;
+
+public enum WatchfaceAction {
+    MENU,
+    WIZARD,
+    BOLUS,
+    ECARB,
+    TEMPT,
+    CPP,
+    PUMP,
+    TDD,
+    LOOP,
+    STATUS,
+    NONE
+}
+

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/WatchfaceZone.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/WatchfaceZone.java
@@ -1,0 +1,12 @@
+package info.nightscout.androidaps.watchfaces;
+
+public enum WatchfaceZone {
+    CHART,
+    BACKGROUND,
+    TOP,
+    DOWN,
+    CENTER,
+    LEFT,
+    RIGHT,
+    NONE
+}

--- a/wear/src/main/res/layout/modern_layout.xml
+++ b/wear/src/main/res/layout/modern_layout.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:id="@+id/main_layout">
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:orientation="vertical" android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/wear/src/main/res/layout/round_activity_home_2.xml
+++ b/wear/src/main/res/layout/round_activity_home_2.xml
@@ -53,6 +53,7 @@
                 android:paddingTop="-2dp"
                 android:text="---"
                 android:textColor="#FFFFFF"
+                android:textStyle="bold"
                 android:textSize="38sp" />
 
             <LinearLayout
@@ -221,7 +222,6 @@
                 android:layout_gravity="center"
                 android:baselineAligned="false"
                 android:gravity="center"
-                android:orientation="horizontal"
                 android:weightSum="7">
 
                 <LinearLayout
@@ -267,7 +267,7 @@
                 <LinearLayout
                     android:layout_width="0px"
                     android:layout_height="match_parent"
-                    android:layout_weight="1"
+                    android:layout_weight="0.8"
                     android:orientation="horizontal" />
 
                 <TextView
@@ -275,11 +275,13 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:gravity="center"
+                    android:gravity="bottom|center_horizontal"
                     android:text="12:00"
+                    android:layout_marginTop="0dp"
                     android:textAlignment="center"
                     android:textColor="#FFFFFF"
-                    android:textSize="30sp" />
+                    android:textSize="30sp"
+                    android:textStyle="bold" />
 
                 <LinearLayout
                     android:id="@+id/date_time"
@@ -300,7 +302,8 @@
                         android:text="day"
                         android:textAlignment="center"
                         android:textColor="#FFFFFF"
-                        android:textSize="12sp" />
+                        android:textSize="12sp"
+                        android:textStyle="bold" />
 
                     <TextView
                         android:id="@+id/month"
@@ -310,14 +313,15 @@
                         android:gravity="center"
                         android:text="mth"
                         android:textColor="#FFFFFF"
-                        android:textSize="12sp" />
+                        android:textSize="12sp"
+                        android:textStyle="bold" />
 
                 </LinearLayout>
 
                 <LinearLayout
                     android:layout_width="0px"
                     android:layout_height="match_parent"
-                    android:layout_weight="1"
+                    android:layout_weight="0.8"
                     android:orientation="horizontal" />
 
                 <LinearLayout
@@ -357,7 +361,7 @@
                 <LinearLayout
                     android:layout_width="0px"
                     android:layout_height="match_parent"
-                    android:layout_weight="1"
+                    android:layout_weight="0"
                     android:orientation="horizontal" />
 
             </LinearLayout>

--- a/wear/src/main/res/layout/round_activity_nochart.xml
+++ b/wear/src/main/res/layout/round_activity_nochart.xml
@@ -102,6 +102,9 @@
                 android:layout_gravity="center_horizontal"
                 android:layout_height="wrap_content" />
         </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="20dp" />
 
     </LinearLayout>
 

--- a/wear/src/main/res/values/arrays.xml
+++ b/wear/src/main/res/values/arrays.xml
@@ -65,4 +65,31 @@
         <item>none</item>
     </string-array>
 
+    <string-array name="watchface_action">
+        <item>@string/menu_menu</item>
+        <item>@string/menu_tempt</item>
+        <item>@string/menu_wizard</item>
+        <item>@string/menu_bolus</item>
+        <item>@string/menu_ecarb</item>
+        <item>@string/menu_status</item>
+        <item>@string/status_pump</item>
+        <item>@string/status_loop</item>
+        <item>@string/status_cpp</item>
+        <item>@string/status_tdd</item>
+        <item>@string/menu_none</item>
+    </string-array>
+
+    <string-array name="watchface_action_values">
+        <item>menu</item>
+        <item>tempt</item>
+        <item>wizard</item>
+        <item>bolus</item>
+        <item>ecarb</item>
+        <item>status</item>
+        <item>pump</item>
+        <item>loop</item>
+        <item>cpp</item>
+        <item>tdd</item>
+        <item>none</item>
+    </string-array>
 </resources>

--- a/wear/src/main/res/values/colors.xml
+++ b/wear/src/main/res/values/colors.xml
@@ -5,8 +5,6 @@
         <color name="wl_gray">#c1c1c1</color>
         <color name="text_color">#434343</color>
     <color name="cardObjectiveText">#779ECB</color>
-
-
     <!-- light colors -->
     <color name="light_bigchart_time">@color/black</color>
     <color name="light_bigchart_status">@color/black</color>
@@ -16,8 +14,10 @@
     <color name="light_mTimestamp">@color/red_600</color>
     <color name="light_highColor">@color/yellow_700</color>
     <color name="light_lowColor">@color/red_600</color>
-    <color name="light_midColor">@color/black</color>
+    <color name="light_midColor">@color/green_300</color>
     <color name="light_gridColor">@color/black</color>
+    <color name="light_carbcolor">@color/carb_700</color>
+
     <!-- dark colors -->
     <color name="dark_mTime">@color/white</color>
     <color name="dark_statusView">@color/white</color>
@@ -32,8 +32,9 @@
 
     <color name="dark_highColor">@color/yellow_A200</color>
     <color name="dark_lowColor">@color/RED</color>
-    <color name="dark_midColor">@color/grey_50</color>
+    <color name="dark_midColor">@color/green_500</color>
     <color name="dark_gridColor">@color/grey_50</color>
+    <color name="dark_carbcolor">@color/carb</color>
 
     <!-- basal colors -->
     <color name="basal_light">@color/blue_300</color>
@@ -64,9 +65,22 @@
     <color name="grey_steampunk">#333333</color>
     <!-- Grey -->
 
-    <!-- Blue Grey -->
+    <!-- Blue -->
     <color name="BLUE">#0000FF</color>
-    <!-- Blue Grey -->
+    <!-- Blue -->
+
+    <!--  Green -->
+    <color name="green_500">#9EFF9E</color>
+    <color name="green">#00FF00</color>
+    <color name="green_300">#01C501</color>
+    <!--  Green -->
+
+    <!-- Carbs Colors -->
+    <color name="carb">#FFA000</color>
+    <color name="carb_700">#E69500</color>
+
+    <!-- Blue Green -->
+
 
     <!-- Black -->
     <color name="black">#000000</color>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -79,6 +79,12 @@
     <string name="menu_default">Default</string>
     <string name="menu_menu">Menu</string>
 
+    <string name="pref_action_top" comment="In menu, set action when double tap on the top of the screen">Top Action</string>
+    <string name="pref_action_down" comment="In menu, set action when double tap on the down of the screen">Down Action</string>
+    <string name="pref_action_left" comment="In menu, set action when double tap on the left of the screen">Left Action</string>
+    <string name="pref_action_right" comment="In menu, set action when double tap on the right of the screen">Right Action</string>
+    <string name="pref_action_center" comment="In menu, set action when double tap on the center of the screen">Center Action</string>
+
     <string name="action_duration">duration</string>
     <string name="action_target" comment="In temp target menu, single target value">target</string>
     <string name="action_low" comment="In temp target menu, lower value from range">low</string>

--- a/wear/src/main/res/xml/preferences.xml
+++ b/wear/src/main/res/xml/preferences.xml
@@ -222,6 +222,47 @@
         app:wear_iconOn="@drawable/settings_on"/>
 
     <ListPreference
+        android:defaultValue="menu"
+        android:entries="@array/watchface_action"
+        android:entryValues="@array/watchface_action_values"
+        android:key="action_top"
+        android:summary="What action after double tap on top"
+        android:title="@string/pref_action_top" />
+
+    <ListPreference
+        android:defaultValue="none"
+        android:entries="@array/watchface_action"
+        android:entryValues="@array/watchface_action_values"
+        android:key="action_down"
+        android:summary="What action after double tap on down"
+        android:title="@string/pref_action_down" />
+
+    <ListPreference
+        android:defaultValue="none"
+        android:entries="@array/watchface_action"
+        android:entryValues="@array/watchface_action_values"
+        android:key="action_left"
+        android:summary="What action after double tap on left"
+        android:title="@string/pref_action_left" />
+
+    <ListPreference
+        android:defaultValue="none"
+        android:entries="@array/watchface_action"
+        android:entryValues="@array/watchface_action_values"
+        android:key="action_center"
+        android:summary="What action after double tap on center"
+        android:title="@string/pref_action_center" />
+
+    <ListPreference
+        android:defaultValue="none"
+        android:entries="@array/watchface_action"
+        android:entryValues="@array/watchface_action_values"
+        android:key="action_right"
+        android:summary="What action after double tap on right"
+        android:title="@string/pref_action_right" />
+
+
+    <ListPreference
         android:defaultValue="default"
         android:entries="@array/complication_tap_action"
         android:entryValues="@array/complication_tap_action_values"


### PR DESCRIPTION
Clean PR for Watchface improvements : 
- 5 customized zones for direct tap actions from watchfaces
- Color improvement in graph (Carb color orange, Bg value in range light green in dark watchface, dark green in bright watchface)
- Color for BG value in range (light green in dark watchface, dark green in bright watchface)
- AAPSv2 : Adjust text size according to watch resolution to improve lisibility
I use it on my Ticwatch pro and it's fine...

AAPSv2 watchface
![screen 22](https://user-images.githubusercontent.com/52934600/71756059-f3933a00-2e8d-11ea-8f7d-e8834da3768a.png)

Settings for each zone
![screen 25](https://user-images.githubusercontent.com/52934600/71756090-11f93580-2e8e-11ea-940e-a9b274154d54.png)

for detailled history of commits see https://github.com/MilosKozak/AndroidAPS/pull/2314

I still have to check with different watch resolutions as @jotomo explained to me for text size (AAPSv2 only)