### PR TITLE
Fix scaling of the activity graph

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphData/GraphData.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphData/GraphData.java
@@ -371,7 +371,8 @@ public class GraphData {
                 actArrayHist.add(new ScaledDataPoint(time, act, actScale));
             else
                 actArrayPred.add(new ScaledDataPoint(time, act, actScale));
-            if (act > maxIAValue) maxIAValue = act;
+            
+            maxIAValue = Math.max(maxIAValue, Math.abs(act));
         }
 
         ScaledDataPoint[] actData = new ScaledDataPoint[actArrayHist.size()];


### PR DESCRIPTION
Right now the scaling only takes positive values into account which leads to a wrong scaling if the amount of negative IOB/activity is larger than the positive amount.