### PR TITLE
[2.6-rc5][fix] Layout fix for bolus progress dialog header text

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,7 +109,7 @@ android {
         targetSdkVersion 28
         multiDexEnabled true
         versionCode 1500
-        version "2.6-dev"
+        version "2.6-rc5"
         buildConfigField "String", "VERSION", '"' + version + '"'
         buildConfigField "String", "BUILDVERSION", '"' + generateGitBuild() + '-' + generateDate() + '"'
         buildConfigField "String", "REMOTE", '"' + generateGitRemote() + '"'

--- a/app/src/main/res/layout/dialog_bolusprogress.xml
+++ b/app/src/main/res/layout/dialog_bolusprogress.xml
@@ -15,6 +15,7 @@
         android:padding="5dp">
 
         <ImageView
+            android:id="@+id/header_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@drawable/ic_trending_flat_white_48dp" />
@@ -28,6 +29,7 @@
             android:layout_marginLeft="10dp"
             android:layout_marginRight="10dp"
             android:textAlignment="center"
+            android:layout_toEndOf="@id/header_icon"
             android:textAppearance="?android:attr/textAppearanceLarge" />
 
     </RelativeLayout>


### PR DESCRIPTION
This fix is for pump progress dialog (examples of bug in #2357) - for longer texts (like in some translation) header text was too long and floated over (obscured by) header icon - fixed by making text to the right of icon in layout

**Was:**

![Screenshot_20200119-071114_AndroidAPS](https://user-images.githubusercontent.com/5094588/72676490-1169bd00-3a92-11ea-9d46-32efbc2aa5af.jpg)

**After fix:**

![Screenshot_20200119-075012_AndroidAPS](https://user-images.githubusercontent.com/5094588/72676491-1169bd00-3a92-11ea-88bd-8aecbcccca86.jpg)
