### PR TITLE
bolusLine in front of carbsLine and offset increased in chart

### DIFF
--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/BgGraphBuilder.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/BgGraphBuilder.java
@@ -213,10 +213,10 @@ public class BgGraphBuilder {
 
         addPredictionLines(lines);
         lines.add(basalLine((float) minChart, factor, highlight));
-        lines.add(bolusLine((float) minChart));
         lines.add(bolusInvalidLine((float) minChart));
         lines.add(carbsLine((float) minChart));
         lines.add(smbLine((float) minChart));
+        lines.add(bolusLine((float) minChart));
 
         return lines;
     }
@@ -249,7 +249,7 @@ public class BgGraphBuilder {
 
         for (BolusWatchData bwd: bolusWatchDataList) {
             if(bwd.date > start_time && bwd.date <= end_time && !bwd.isSMB && bwd.isValid && bwd.bolus > 0) {
-                pointValues.add(new PointValue(fuzz(bwd.date), (float) offset-2));
+                pointValues.add(new PointValue(fuzz(bwd.date), (float) offset-2*pointSize));
             }
         }
         Line line = new Line(pointValues);
@@ -266,7 +266,7 @@ public class BgGraphBuilder {
 
         for (BolusWatchData bwd: bolusWatchDataList) {
             if(bwd.date > start_time && bwd.date <= end_time && bwd.isSMB && bwd.isValid && bwd.bolus > 0) {
-                pointValues.add(new PointValue(fuzz(bwd.date), (float) offset-2));
+                pointValues.add(new PointValue(fuzz(bwd.date), (float) offset-2*pointSize));
             }
         }
         Line line = new Line(pointValues);
@@ -283,7 +283,7 @@ public class BgGraphBuilder {
 
         for (BolusWatchData bwd: bolusWatchDataList) {
             if(bwd.date > start_time && bwd.date <= end_time && !(bwd.isValid && (bwd.bolus > 0 || bwd.carbs > 0))) {
-                pointValues.add(new PointValue(fuzz(bwd.date), (float) offset-2));
+                pointValues.add(new PointValue(fuzz(bwd.date), (float) offset-2*pointSize));
             }
         }
         Line line = new Line(pointValues);
@@ -300,7 +300,7 @@ public class BgGraphBuilder {
 
         for (BolusWatchData bwd: bolusWatchDataList) {
             if(bwd.date > start_time && bwd.date <= end_time && !bwd.isSMB && bwd.isValid && bwd.carbs > 0) {
-                pointValues.add(new PointValue(fuzz(bwd.date), (float) offset+2));
+                pointValues.add(new PointValue(fuzz(bwd.date), (float) offset+2*pointSize));
             }
         }
         Line line = new Line(pointValues);


### PR DESCRIPTION
I propose to replace the `2` pixels offset (above minchart for carbsLine and below for bolusLine, smbLine and bolusInvalidLine) by `2*pointSize` Offset
=> In this way, we can easily see the two points even if at the same time 

I have put bolusLine in front of carbLine to be consistent with smbLine (points smaller and currently in front of Carbs)

Note: the contrast is better with the orange points for carbs than with the green points (cf. https://github.com/MilosKozak/AndroidAPS/pull/2390) ...

Currently:
![screen 37](https://user-images.githubusercontent.com/52934600/73310961-9a68bd00-4225-11ea-809c-f0f9e6c78a8b.png)

After change:
![screen 38](https://user-images.githubusercontent.com/52934600/73310987-a9e80600-4225-11ea-8704-9883e5846444.png)

