### PR TITLE
Add NiMH battery option for Medtronic pumps

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/dto/BatteryStatusDTO.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/dto/BatteryStatusDTO.java
@@ -40,11 +40,12 @@ public class BatteryStatusDTO {
 
 
     public String toString() {
-        return String.format(Locale.ENGLISH, "BatteryStatusDTO [voltage=%.2f, alkaline=%d, lithium=%d, niZn={}]",
+        return String.format(Locale.ENGLISH, "BatteryStatusDTO [voltage=%.2f, alkaline=%d, lithium=%d, niZn=%d, nimh=%d]",
                 voltage == null ? 0.0f : voltage,
                 getCalculatedPercent(BatteryType.Alkaline),
                 getCalculatedPercent(BatteryType.Lithium),
-                getCalculatedPercent(BatteryType.NiZn));
+                getCalculatedPercent(BatteryType.NiZn),
+                getCalculatedPercent(BatteryType.NiMH));
     }
 
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/defs/BatteryType.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/defs/BatteryType.java
@@ -15,7 +15,8 @@ public enum BatteryType {
     None(R.string.key_medtronic_pump_battery_no, 0, 0),
     Alkaline(R.string.key_medtronic_pump_battery_alkaline, 1.20d, 1.47d), //
     Lithium(R.string.key_medtronic_pump_battery_lithium, 1.22d, 1.64d), //
-    NiZn(R.string.key_medtronic_pump_battery_nizn, 1.40d, 1.70d) //
+    NiZn(R.string.key_medtronic_pump_battery_nizn, 1.40d, 1.70d), //
+    NiMH(R.string.key_medtronic_pump_battery_nimh, 1.10d, 1.40d) //
     ;
 
     private final String description;

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -191,6 +191,7 @@
         <item>@string/medtronic_pump_battery_alkaline</item>
         <item>@string/medtronic_pump_battery_lithium</item>
         <item>@string/medtronic_pump_battery_nizn</item>
+        <item>@string/medtronic_pump_battery_nimh</item>
     </string-array>
 
     <string-array name="medtronicBatteryTypeValues">
@@ -198,6 +199,7 @@
         <item>@string/key_medtronic_pump_battery_alkaline</item>
         <item>@string/key_medtronic_pump_battery_lithium</item>
         <item>@string/key_medtronic_pump_battery_nizn</item>
+        <item>@string/key_medtronic_pump_battery_nimh</item>
     </string-array>
 
     <string-array name="smbMaxMinutes">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1449,6 +1449,7 @@
     <string name="key_medtronic_pump_battery_alkaline" translatable="false">medtronic_pump_battery_alkaline</string>
     <string name="key_medtronic_pump_battery_lithium" translatable="false">medtronic_pump_battery_lithium</string>
     <string name="key_medtronic_pump_battery_nizn" translatable="false">medtronic_pump_battery_nizn</string>
+    <string name="key_medtronic_pump_battery_nimh" translatable="false">medtronic_pump_battery_nimh</string>
 
     <string name="medtronic_serial_number">Pump Serial Number</string>
     <string name="medtronic_pump_type">Pump Type</string>
@@ -1469,6 +1470,7 @@
     <string name="medtronic_pump_battery_alkaline">Alkaline (Extended view)</string>
     <string name="medtronic_pump_battery_lithium">Lithium (Extended view)</string>
     <string name="medtronic_pump_battery_nizn">NiZn (Extended view)</string>
+    <string name="medtronic_pump_battery_nimh">NiMH (Extended view)</string>
     <string name="medtronic_bolus_debugging">Bolus/Treatments Debugging</string>
 
     <!-- RL BLE Scanning -->


### PR DESCRIPTION
I prefer to use rechargeables in my gear, but there wasn't an option for a Nickle-Metal Hydride, the most common option these days. This should add that with the proper voltages as based on several discharge charts I found online.

e.g. https://eneloop101.com/batteries/eneloop-test-results/