### PR TITLE
Use google key/value backup agent for settings and objectives

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,14 @@
         android:roundIcon="${appIconRound}"
         android:supportsRtl="true"
         android:theme="@style/AppTheme.Launcher"
-        android:fullBackupContent="true">
+        android:fullBackupOnly="false"
+        android:backupAgent=".utils.SPBackupAgent"
+        android:restoreAnyVersion="true">
+
+        <meta-data
+            android:name="com.google.android.backup.api_key"
+            android:value="AEdPqrEAAAAI3JiApyMrbP2QFzZ2fYfCPsgjkRp53Dm2S1-zPQ" />
+
         <meta-data
             android:name="com.google.android.gms.car.application"
             android:resource="@xml/automotive_app_desc" />

--- a/app/src/main/java/info/nightscout/androidaps/utils/SPBackupAgent.java
+++ b/app/src/main/java/info/nightscout/androidaps/utils/SPBackupAgent.java
@@ -1,0 +1,24 @@
+package info.nightscout.androidaps.utils;
+
+import android.app.backup.BackupAgentHelper;
+import android.app.backup.SharedPreferencesBackupHelper;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import info.nightscout.androidaps.MainApp;
+
+public class SPBackupAgent extends BackupAgentHelper {
+
+    // API 24
+    //static final String PREFS = PreferenceManager.getDefaultSharedPreferencesName(MainApp.instance().getApplicationContext());
+    static final String PREFS = MainApp.instance().getApplicationContext().getPackageName() + "_preferences";
+
+    static final String PREFS_BACKUP_KEY = "SP";
+
+    @Override
+    public void onCreate() {
+        SharedPreferencesBackupHelper helper =
+                new SharedPreferencesBackupHelper(this, PREFS);
+        addHelper(PREFS_BACKUP_KEY, helper);
+    }
+}


### PR DESCRIPTION
This switches from auto backup to key-value backup.

Auto backup doesn't seem to be a good choice for AAPS backup because:

1) Auto backups only run if the app is not active (which almost never happens with AAPS)
2) AAPS stores a large amount of data which tends to exceed the 25MB limit imposed causing backups to be disabled

This PR avoids the issues by only backing up shared preferences and using the older key-value backup system which doesn't require the app to be shutdown.

On re-installing AAPS the wizard is not run but the user is correctly prompted for permissions at the top of the screen. It seems to sometimes be necessary to restart AAPS for the settings to be fully applied.

This isn't as reliable as the import/export settings, but it gives another chance to recover if an export is not available.

