### PR TITLE
Combo: like with bolus record, allow updating existing record for car…

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ComboPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ComboPlugin.java
@@ -472,7 +472,7 @@ public class ComboPlugin extends PluginBase implements PumpInterface, Constraint
                 return deliverBolus(detailedBolusInfo);
             } else {
                 // no bolus required, carb only treatment
-                TreatmentsPlugin.getPlugin().addToHistoryTreatment(detailedBolusInfo, false);
+                TreatmentsPlugin.getPlugin().addToHistoryTreatment(detailedBolusInfo, true);
 
                 EventOverviewBolusProgress bolusingEvent = EventOverviewBolusProgress.INSTANCE;
                 bolusingEvent.setT(new Treatment());


### PR DESCRIPTION
…b-only treatment as well.

For carb-only treatments Combo-code simply does nothing beyond calling _addToHistoryTreatment_. Align the code to allown merging of records in this case as well. Such a change was done previously for a request to add bolus (and carbs).

Untested as of now

#2472 @AdrianLxM @MilosKozak 