### PR TITLE
Alert for pump unreachable not working

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/receivers/KeepAliveReceiver.kt
+++ b/app/src/main/java/info/nightscout/androidaps/receivers/KeepAliveReceiver.kt
@@ -99,7 +99,7 @@ class KeepAliveReceiver : BroadcastReceiver() {
                 log.debug("Last connection: " + DateUtil.dateAndTimeString(lastConnection))
             // sometimes keep alive broadcast stops
             // as as workaround test if readStatus was requested before an alarm is generated
-            if (lastReadStatus != 0L && lastReadStatus > System.currentTimeMillis() - T.mins(5).msecs()) {
+            if (lastReadStatus == 0L && lastConnection < System.currentTimeMillis() - T.mins(5).msecs()) {
                 LocalAlertUtils.checkPumpUnreachableAlarm(lastConnection, isStatusOutdated)
             }
             if (!pump.isThisProfileSet(profile) && !ConfigBuilderPlugin.getPlugin().commandQueue.isRunning(Command.CommandType.BASALPROFILE)) {


### PR DESCRIPTION
This has worked for me to get the alert to always work, where before it would more often not work and I'd find the last connection over 4 hrs ago and no alert.

Others having issues like seen in #2505 

