### PR TITLE
Fix order of insight histories

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/data/PumpEnactResult.java
+++ b/app/src/main/java/info/nightscout/androidaps/data/PumpEnactResult.java
@@ -23,7 +23,7 @@ public class PumpEnactResult {
     public double absolute = -1d;      // absolute rate [U/h] , isPercent = false
     public int percent = -1;       // percent of current basal [%] (100% = current basal), isPercent = true
     public boolean isPercent = false;  // if true percent is used, otherwise absolute
-    public boolean isTempCancel = false; // if true we are caceling temp basal
+    public boolean isTempCancel = false; // if true we are canceling temp basal
     // Result of treatment delivery
     public double bolusDelivered = 0d; // real value of delivered insulin
     public double carbsDelivered = 0d; // real value of delivered carbs

--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
@@ -361,6 +361,7 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
         calendar.set(Calendar.HOUR_OF_DAY, pumpTime.getHour());
         calendar.set(Calendar.MINUTE, pumpTime.getMinute());
         calendar.set(Calendar.SECOND, pumpTime.getSecond());
+        calendar.set(Calendar.MILLISECOND, 0); // truncate leftover milliseconds from current time
         if (calendar.get(Calendar.HOUR_OF_DAY) != pumpTime.getHour() || Math.abs(calendar.getTimeInMillis() - System.currentTimeMillis()) > 10000) {
             calendar.setTime(new Date());
             pumpTime.setYear(calendar.get(Calendar.YEAR));
@@ -1141,10 +1142,13 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
 
     private void readHistory() {
         try {
-            PumpTime pumpTime = connectionService.requestMessage(new GetDateTimeMessage()).await().getPumpTime();
             String pumpSerial = connectionService.getPumpSystemIdentification().getSerialNumber();
+
+            // compute the delta between device and pump time so we can correct historyEvents to match device time
+            PumpTime pumpTime = connectionService.requestMessage(new GetDateTimeMessage()).await().getPumpTime();
             timeOffset = Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTimeInMillis() - parseDate(pumpTime.getYear(),
                     pumpTime.getMonth(), pumpTime.getDay(), pumpTime.getHour(), pumpTime.getMinute(), pumpTime.getSecond());
+
             InsightHistoryOffset historyOffset = MainApp.getDbHelper().getInsightHistoryOffset(pumpSerial);
             try {
                 List<HistoryEvent> historyEvents = new ArrayList<>();
@@ -1165,7 +1169,7 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
                         historyEvents.addAll(newEvents);
                     }
                 }
-                Collections.sort(historyEvents);
+                Collections.sort(historyEvents); // sorts by eventPosition ascending, oldest event first
                 Collections.reverse(historyEvents);
                 if (historyOffset != null) processHistoryEvents(pumpSerial, historyEvents);
                 if (historyEvents.size() > 0) {
@@ -1197,12 +1201,25 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
     }
 
     private void processHistoryEvents(String serial, List<HistoryEvent> historyEvents) {
+        // this method expects historyEvents to be sorted from new to old in order to account for time changes.
+        // timeOffset is computed to be the current offset between device and pump and we will update this offset
+        // when we detect that the pump time has changed
         List<TemporaryBasal> temporaryBasals = new ArrayList<>();
         List<InsightPumpID> pumpStartedEvents = new ArrayList<>();
         for (HistoryEvent historyEvent : historyEvents)
             if (!processHistoryEvent(serial, temporaryBasals, pumpStartedEvents, historyEvent))
                 break;
         Collections.reverse(temporaryBasals);
+        for (int i = 0; i + 1 < temporaryBasals.size(); i++) {
+            TemporaryBasal current = temporaryBasals.get(i);
+            TemporaryBasal next = temporaryBasals.get(i + 1);
+            // remove cancel TBR records if they're immediately followed by another TBR record since
+            // they have no benefit and only one TBR in the same second can be saved to the db
+            if (current.durationInMinutes == 0 && Math.abs(next.date - current.date) < 1000) {
+                temporaryBasals.remove(i);
+                i--;
+            }
+        }
         for (InsightPumpID pumpID : pumpStartedEvents) {
             InsightPumpID stoppedEvent = MainApp.getDbHelper().getPumpStoppedEvent(pumpID.pumpSerial, pumpID.timestamp);
             if (stoppedEvent == null || stoppedEvent.eventType.equals("PumpPaused")) continue;
@@ -1537,6 +1554,7 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
         calendar.set(Calendar.HOUR_OF_DAY, hour);
         calendar.set(Calendar.MINUTE, minute);
         calendar.set(Calendar.SECOND, second);
+        calendar.set(Calendar.MILLISECOND, 0); // truncate leftover milliseconds from current UTC time
         return calendar.getTimeInMillis();
     }
 
@@ -1572,6 +1590,7 @@ public class LocalInsightPlugin extends PluginBase implements PumpInterface, Con
         calendar.set(Calendar.HOUR_OF_DAY, relativeHour);
         calendar.set(Calendar.MINUTE, relativeMinute);
         calendar.set(Calendar.SECOND, relativeSecond);
+        calendar.set(Calendar.MILLISECOND, 0); // truncate leftover milliseconds from current UTC time
         return calendar.getTimeInMillis();
     }
 


### PR DESCRIPTION
The insight pump only supports second precision so when a TBR is changed, this is a quick succession of "cancel TBR" + "set TBR" in the same second. The code sorts the events multiple times and processes the events from new to old for some reason. This leads to the "set TBR" record to be inserted first sometimes and then the database will update the "set TBR" record to be the "cancel TBR" record since they happened in the same second so we can't rely on timestamp to tell us if one event happened before another. Luckily the insight has a monotonically increasing eventPosition id we can sort by to have the events in order of happening. By just avoiding sorting all over the place we can keep and process the events from old to new. We still override the "cancel TBR" with the "set TBR" with this fix but this does not appear to be a problem.

Additionally, i've noticed that the historyEvents curiously enough had random milliseconds attached to them which were a artifact of how the timestamp were computed.

Fixes #2484
Fixes #2435