### PR TITLE
SMS Carb command update

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
@@ -713,6 +713,7 @@ object SmsCommunicatorPlugin : PluginBase(PluginDescription()
                 override fun run() {
                     val detailedBolusInfo = DetailedBolusInfo()
                     detailedBolusInfo.carbs = anInteger().toDouble()
+                    detailedBolusInfo.source = Source.USER
                     detailedBolusInfo.date = secondLong()
                     ConfigBuilderPlugin.getPlugin().commandQueue.bolus(detailedBolusInfo, object : Callback() {
                         override fun run() {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
@@ -715,19 +715,26 @@ object SmsCommunicatorPlugin : PluginBase(PluginDescription()
                     detailedBolusInfo.carbs = anInteger().toDouble()
                     detailedBolusInfo.source = Source.USER
                     detailedBolusInfo.date = secondLong()
-                    ConfigBuilderPlugin.getPlugin().commandQueue.bolus(detailedBolusInfo, object : Callback() {
-                        override fun run() {
-                            if (result.success) {
-                                var replyText = String.format(MainApp.gs(R.string.smscommunicator_carbsset), anInteger)
-                                replyText += "\n" + ConfigBuilderPlugin.getPlugin().activePump?.shortStatus(true)
-                                sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
-                            } else {
-                                var replyText = MainApp.gs(R.string.smscommunicator_carbsfailed)
-                                replyText += "\n" + ConfigBuilderPlugin.getPlugin().activePump?.shortStatus(true)
-                                sendSMS(Sms(receivedSms.phoneNumber, replyText))
+                    if (ConfigBuilderPlugin.getPlugin().activePump?.pumpDescription?.storesCarbInfo == true) {
+                        ConfigBuilderPlugin.getPlugin().commandQueue.bolus(detailedBolusInfo, object : Callback() {
+                            override fun run() {
+                                if (result.success) {
+                                    var replyText = String.format(MainApp.gs(R.string.smscommunicator_carbsset), anInteger)
+                                    replyText += "\n" + ConfigBuilderPlugin.getPlugin().activePump?.shortStatus(true)
+                                    sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                                } else {
+                                    var replyText = MainApp.gs(R.string.smscommunicator_carbsfailed)
+                                    replyText += "\n" + ConfigBuilderPlugin.getPlugin().activePump?.shortStatus(true)
+                                    sendSMS(Sms(receivedSms.phoneNumber, replyText))
+                                }
                             }
-                        }
-                    })
+                        })
+                    } else {
+                        TreatmentsPlugin.getPlugin().addToHistoryTreatment(detailedBolusInfo, true)
+                        var replyText = String.format(MainApp.gs(R.string.smscommunicator_carbsset), anInteger)
+                        replyText += "\n" + ConfigBuilderPlugin.getPlugin().activePump?.shortStatus(true)
+                        sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                    }
                 }
             })
         }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/treatments/TreatmentService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/treatments/TreatmentService.java
@@ -280,6 +280,10 @@ public class TreatmentService extends OrmLiteBaseService<DatabaseHelper> {
 
     // return true if new record is created
     public UpdateReturn createOrUpdate(Treatment treatment) {
+        if (treatment != null && treatment.source == Source.NONE) {
+            log.error("Coder error: source is not set for treatment: " + treatment, new Exception());
+            FabricPrivacy.logException(new Exception("Coder error: source is not set for treatment: " + treatment));
+        }
         try {
             Treatment old;
             treatment.date = DatabaseHelper.roundDateToSec(treatment.date);


### PR DESCRIPTION
@TebbeUbben You're right that a pump driver without carb support shouldn't be bothered to open a connection pointlessly. This takes a smaller step approach by aligning the SMS communicator to the way such requests are handled in other places, by checking the PumpDescription and adding carbs via TreatmentPlugin directly if the pump doesn't store carb info.
Any refactorings around that area should go into 2.7, while this is a bugfix for 2.6.