### PR TITLE
Fixed crash on pre-26 API due to lack of java.time.Duration in depenent OTP lib

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/otp/OneTimePassword.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/otp/OneTimePassword.kt
@@ -1,7 +1,7 @@
 package info.nightscout.androidaps.plugins.general.smsCommunicator.otp
 
 import android.util.Base64
-import com.eatthepath.otp.TimeBasedOneTimePasswordGenerator
+import com.eatthepath.otp.HmacOneTimePasswordGenerator
 import com.google.common.io.BaseEncoding
 import info.nightscout.androidaps.Constants
 import info.nightscout.androidaps.R
@@ -23,7 +23,7 @@ class OneTimePassword @Inject constructor(
 
     private var key: SecretKey? = null
     private var pin: String = ""
-    private val totp = TimeBasedOneTimePasswordGenerator()
+    private val totp = HmacOneTimePasswordGenerator()
 
     init {
         instance = this


### PR DESCRIPTION
This is utterly strange bug, we used only methods from base class, that were Java 1.8 time (min API 26) independent, but accessed them trough child class that have Duration field.

Compiler do not report is as dependency and allow to compile with min API 23, but at runtime on pre 26 it crashes due to API-26 dependency. 