### PR TITLE
Force Short Text in Status light (proposal)

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/StatusLightHandler.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/StatusLightHandler.kt
@@ -135,11 +135,11 @@ class StatusLightHandler @Inject constructor(
         handleAge(age, "", eventType, warnThreshold, urgentThreshold)
 
     fun handleAge(age: TextView?, prefix: String, eventType: String, warnThreshold: Double, urgentThreshold: Double) {
-        val notavailable = "-"
+        val notavailable = if (resourceHelper.shortTextMode()) "-" else resourceHelper.gs(R.string.notavailable)
         val careportalEvent = MainApp.getDbHelper().getLastCareportalEvent(eventType)
         if (careportalEvent != null) {
             age?.setTextColor(determineTextColor(careportalEvent, warnThreshold, urgentThreshold))
-            age?.text = prefix + careportalEvent.age(true)
+            age?.text = prefix + careportalEvent.age(resourceHelper.shortTextMode())
         } else {
             age?.text = notavailable
         }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/StatusLightHandler.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/StatusLightHandler.kt
@@ -135,11 +135,11 @@ class StatusLightHandler @Inject constructor(
         handleAge(age, "", eventType, warnThreshold, urgentThreshold)
 
     fun handleAge(age: TextView?, prefix: String, eventType: String, warnThreshold: Double, urgentThreshold: Double) {
-        val notavailable = if (resourceHelper.shortTextMode()) "-" else resourceHelper.gs(R.string.notavailable)
+        val notavailable = "-"
         val careportalEvent = MainApp.getDbHelper().getLastCareportalEvent(eventType)
         if (careportalEvent != null) {
             age?.setTextColor(determineTextColor(careportalEvent, warnThreshold, urgentThreshold))
-            age?.text = prefix + careportalEvent.age(resourceHelper.shortTextMode())
+            age?.text = prefix + careportalEvent.age(true)
         } else {
             age?.text = notavailable
         }

--- a/app/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelperImplementation.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelperImplementation.kt
@@ -69,5 +69,5 @@ class ResourceHelperImplementation @Inject constructor(private val context: Cont
         return (dp * scale + 0.5f).toInt()
     }
 
-    override fun shortTextMode() : Boolean = !gb(R.bool.isTablet) && Config.NSCLIENT
+    override fun shortTextMode() : Boolean = !(gb(R.bool.isTablet) && Config.NSCLIENT)
 }


### PR DESCRIPTION
It's just a proposal: Long text for status lights are too long in a phone in portrait mode (even in english it's too long, in french it's worse)
Here I forced short text, but may be if you want long text for tablets you could change how you switch between short and long text...

![StatusLight_Short](https://user-images.githubusercontent.com/52934600/79045491-b3b9bc80-7c0b-11ea-9fc3-e7d9651fbb72.jpg)
