### PR TITLE
Split check in gradle to better warn about GIT / admin right issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,6 +82,23 @@ def isMaster = { ->
     return !version.contains('-')
 }
 
+def gitAvailable = { ->
+    StringBuilder stringBuilder = new StringBuilder()
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', '--version'
+            standardOutput = stdout
+        }
+        String commitObject = stdout.toString().trim()
+        stringBuilder.append(commitObject)
+    } catch (ignored) {
+        return false // NoGitSystemAvailable
+    }
+    return !stringBuilder.toString().isEmpty()
+
+}
+
 def allCommited = { ->
     StringBuilder stringBuilder = new StringBuilder()
     try {
@@ -393,9 +410,13 @@ preBuild.dependsOn copyLibs
 
 printf('--------------\n')
 printf('isMaster: %s\n', isMaster().toString())
+printf('gitAvailable: %s\n', gitAvailable().toString())
 printf('allCommited: %s\n', allCommited().toString())
 printf('--------------\n')
+if (isMaster() && !gitAvailable()) {
+    throw new GradleException('GIT system is not available. On Windows try to run Android Studio as an Administrator. Check if GIT is installed and Studio have permissions to use it')
+}
 if (isMaster() && !allCommited()) {
-    throw new GradleException('There are uncommitted changes or git system is not available. Clone sources again as described in wiki and do not allow gradle update')
+    throw new GradleException('There are uncommitted changes. Clone sources again as described in wiki and do not allow gradle update')
 }
 


### PR DESCRIPTION
Added standalone check for git (using git --version) to first check if git works at all before we will use it to check local copy status.

Sometimes after Android Studio update, git cannot be called directly from it, unless Android Studio is run once as Administrator. It is hard to debug since standard hint (clone sources) does not help, and checking git from cmd.exe does not show issues (it works).

By splitting this check we proof directly from Studio if it can call git