### PR TITLE
InsightAlertservice: handle nullable intent.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/InsightAlertService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/insight/InsightAlertService.java
@@ -104,8 +104,10 @@ public class InsightAlertService extends Service implements InsightConnectionSer
     }
 
     @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
-        if ("mute".equals(intent.getStringExtra("command"))) {
+    public int onStartCommand(@Nullable Intent intent, int flags, int startId) {
+        if (intent == null) {
+            // service is being restarted
+        } else if ("mute".equals(intent.getStringExtra("command"))) {
             mute();
         } else if ("confirm".equals(intent.getStringExtra("command"))) {
             dismissNotification();


### PR DESCRIPTION
@TebbeUbben cause of #2569 and #2571:
```
java.lang.RuntimeException: Unable to start service info.nightscout.androidaps.plugins.pump.insight.InsightAlertService@7844bc3 with null: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.Intent.getStringExtra(java.lang.String)' on a null object reference
	at android.app.ActivityThread.handleServiceArgs(Unknown Source:134) ~[na:0.0]
	at android.app.ActivityThread.access$1900(Unknown Source:0) ~[na:0.0]
	at android.app.ActivityThread$H.handleMessage(Unknown Source:613) ~[na:0.0]
	at android.os.Handler.dispatchMessage(Unknown Source:19) ~[na:0.0]
	at android.os.Looper.loop(Unknown Source:242) ~[na:0.0]
	at android.app.ActivityThread.main(Unknown Source:98) ~[na:0.0]
	at java.lang.reflect.Method.invoke(Native Method) ~[na:0.0]
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(Unknown Source:11) ~[na:0.0]
	at com.android.internal.os.ZygoteInit.main(Unknown Source:275) ~[na:0.0]
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.Intent.getStringExtra(java.lang.String)' on a null object reference
	at info.nightscout.androidaps.plugins.pump.insight.InsightAlertService.onStartCommand(InsightAlertService.java:108) ~[na:0.0]
	at android.app.ActivityThread.handleServiceArgs(Unknown Source:40) ~[na:0.0]
	... 8 common frames omitted
```