### PR TITLE
- fix for dagger injection of RileyLinkMedtronicService (removed dupl…

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/service/RileyLinkService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/service/RileyLinkService.java
@@ -33,9 +33,9 @@ import static info.nightscout.androidaps.plugins.pump.common.hw.rileylink.RileyL
  */
 public abstract class RileyLinkService extends DaggerService {
 
-    @Inject AAPSLogger aapsLogger;
-    @Inject SP sp;
-    @Inject Context context;
+    @Inject protected AAPSLogger aapsLogger;
+    @Inject protected SP sp;
+    @Inject protected Context context;
 
 
     public RileyLinkBLE rileyLinkBLE; // android-bluetooth management

--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/service/RileyLinkMedtronicService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/service/RileyLinkMedtronicService.java
@@ -36,10 +36,10 @@ import info.nightscout.androidaps.utils.sharedPreferences.SP;
  */
 public class RileyLinkMedtronicService extends RileyLinkService {
 
-    @Inject AAPSLogger aapsLogger;
-    @Inject Context context;
+    //@Inject AAPSLogger aapsLogger;
+    //@Inject Context context;
     @Inject MedtronicPumpPlugin medtronicPumpPlugin;
-    @Inject SP sp;
+    //@Inject SP sp;
 
     private static RileyLinkMedtronicService instance;
     private static ServiceTask currentTask = null;
@@ -53,9 +53,6 @@ public class RileyLinkMedtronicService extends RileyLinkService {
     public RileyLinkMedtronicService() {
         super();
         instance = this;
-        aapsLogger.debug(LTag.PUMPCOMM, "RileyLinkMedtronicService newly constructed");
-        MedtronicUtil.setMedtronicService(this);
-        pumpStatus = (MedtronicPumpStatus) medtronicPumpPlugin.getPumpStatusData();
     }
 
 
@@ -106,6 +103,11 @@ public class RileyLinkMedtronicService extends RileyLinkService {
 
         // init rileyLinkCommunicationManager
         medtronicCommunicationManager = new MedtronicCommunicationManager(context, rfspy);
+
+        aapsLogger.debug(LTag.PUMPCOMM, "RileyLinkMedtronicService newly constructed");
+        MedtronicUtil.setMedtronicService(this);
+        pumpStatus = (MedtronicPumpStatus) medtronicPumpPlugin.getPumpStatusData();
+
     }
 
 


### PR DESCRIPTION
…icate variables), and moved code to different location, because we can use injected variables before onCreate is called