### PR TITLE
Removed internal function

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/utils/textValidator/ValidatingEditTextPreference.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/textValidator/ValidatingEditTextPreference.kt
@@ -2,7 +2,6 @@ package info.nightscout.androidaps.utils.textValidator
 
 import android.content.Context
 import android.util.AttributeSet
-import androidx.core.content.res.TypedArrayUtils
 import androidx.preference.EditTextPreference
 import androidx.preference.EditTextPreference.OnBindEditTextListener
 import androidx.preference.PreferenceViewHolder
@@ -23,8 +22,7 @@ class ValidatingEditTextPreference(ctx: Context, attrs: AttributeSet, defStyleAt
         : this(ctx, attrs, defStyle, 0)
 
     constructor(ctx: Context, attrs: AttributeSet)
-        : this(ctx, attrs, TypedArrayUtils.getAttr(ctx, R.attr.editTextPreferenceStyle,
-        R.attr.editTextPreferenceStyle))
+        : this(ctx, attrs, R.attr.editTextPreferenceStyle)
 
     private lateinit var editTextValidator: EditTextValidator
 


### PR DESCRIPTION
TypedArrayUtils is marked as `@RestrictTo(LIBRARY_GROUP_PREFIX)`.
getAttr() will chose between the two parameters, so if both are the same has no functionality anyway.