### PR TITLE
Kotlin interface not stricter than Java superclass

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/food/FoodFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/food/FoodFragment.kt
@@ -58,7 +58,7 @@ class FoodFragment : DaggerFragment() {
             filterData()
         }
         food_category.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-            override fun onItemSelected(parent: AdapterView<*>?, view: View, position: Int, id: Long) {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
                 fillSubcategories()
                 filterData()
             }
@@ -69,7 +69,7 @@ class FoodFragment : DaggerFragment() {
             }
         }
         food_subcategory.setOnItemSelectedListener(object : AdapterView.OnItemSelectedListener {
-            override fun onItemSelected(parent: AdapterView<*>?, view: View, position: Int, id: Long) {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
                 filterData()
             }
 


### PR DESCRIPTION
Intrinsic check in Kotlin if view is null lead to crashes.
view is not even used so we can accept null.