### PR TITLE
Fix issue #2594 (crash when Preferences are opened on Wear variant)

### DIFF
--- a/wear/src/main/res/xml/preferences.xml
+++ b/wear/src/main/res/xml/preferences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <CheckBoxPreference
@@ -244,4 +244,4 @@
         android:key="version_number"
         android:summary="Input Design"
         android:title="@string/pref_version" />
-</androidx.preference.PreferenceScreen>
+</PreferenceScreen>


### PR DESCRIPTION
WearPreferencesAcivity on WearOS does not allow prefixing of root XML tag with `androidx.preference.` - it caused crash when Preferences was opened.
Using simply `<PreferenceScreen>` fix the issue :)
