### PR TITLE
Show oref internal overridden targets

### DIFF
--- a/app/src/main/assets/OpenAPSSMB/determine-basal.js
+++ b/app/src/main/assets/OpenAPSSMB/determine-basal.js
@@ -407,6 +407,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         , 'bg': bg
         , 'tick': tick
         , 'eventualBG': eventualBG
+        , 'targetBG': target_bg
         , 'insulinReq': 0
         , 'reservoir' : reservoir_data // The expected reservoir volume at which to deliver the microbolus (the reservoir volume from right before the last pumphistory run)
         , 'deliverAt' : deliverAt // The time at which the microbolus should be delivered

--- a/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSSMB/DetermineBasalResultSMB.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSSMB/DetermineBasalResultSMB.java
@@ -51,6 +51,9 @@ public class DetermineBasalResultSMB extends APSResult {
             } else {
                 smb = 0d;
             }
+            if (result.has("targetBG")) {
+                targetBG = result.getDouble("targetBG");
+            }
 
             if (result.has("deliverAt")) {
                 String date = result.getString("deliverAt");

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -646,6 +646,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         } else {
             overview_apsmode_text?.visibility = View.GONE
         }
+        val lastRun = loopPlugin.lastRun
 
         // temp target
         val tempTarget = treatmentsPlugin.tempTargetFromHistory
@@ -654,9 +655,27 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
             overview_temptarget?.setBackgroundColor(resourceHelper.gc(R.color.ribbonWarning))
             overview_temptarget?.text = Profile.toTargetRangeString(tempTarget.low, tempTarget.high, Constants.MGDL, units) + " " + DateUtil.untilString(tempTarget.end(), resourceHelper)
         } else {
-            overview_temptarget?.setTextColor(resourceHelper.gc(R.color.ribbonTextDefault))
-            overview_temptarget?.setBackgroundColor(resourceHelper.gc(R.color.ribbonDefault))
-            overview_temptarget?.text = Profile.toTargetRangeString(profile.targetLowMgdl, profile.targetHighMgdl, Constants.MGDL, units)
+            //If the target is not the same as set in the profile then oref has overridden it
+            //show this change to the user if it exists
+            if (lastRun != null){
+                var targetused = lastRun!!.constraintsProcessed!!.targetBG
+                if (units == Constants.MMOL)
+                    targetused *= Constants.MGDL_TO_MMOLL
+
+                if (profile.targetUnits != targetused) {
+                    overview_temptarget?.text = targetused.toString()
+                    overview_temptarget?.setTextColor(resourceHelper.gc(R.color.ribbonTextWarning))
+                    overview_temptarget?.setBackgroundColor(resourceHelper.gc(R.color.tempTargetBackground))
+                }else{
+                    overview_temptarget?.setTextColor(resourceHelper.gc(R.color.ribbonTextDefault))
+                    overview_temptarget?.setBackgroundColor(resourceHelper.gc(R.color.ribbonDefault))
+                    overview_temptarget?.text = Profile.toTargetRangeString(profile.targetLowMgdl, profile.targetHighMgdl, Constants.MGDL, units)
+                }
+            }else {
+                overview_temptarget?.setTextColor(resourceHelper.gc(R.color.ribbonTextDefault))
+                overview_temptarget?.setBackgroundColor(resourceHelper.gc(R.color.ribbonDefault))
+                overview_temptarget?.text = Profile.toTargetRangeString(profile.targetLowMgdl, profile.targetHighMgdl, Constants.MGDL, units)
+            }
         }
 
         // Basal, TBR
@@ -741,7 +760,6 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         }
         overview_cob?.text = cobText
 
-        val lastRun = loopPlugin.lastRun
         val predictionsAvailable = if (config.APS) lastRun?.request?.hasPredictions == true else config.NSCLIENT
 
         // pump status from ns

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -659,11 +659,9 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
             //show this change to the user if it exists
             var targetused = lastRun?.constraintsProcessed?.targetBG
             if (targetused != null && targetused != 0.0) {
-                if (units == Constants.MMOL)
-                    targetused *= Constants.MGDL_TO_MMOLL
 
-                if (profile.targetUnits != targetused) {
-                    overview_temptarget?.text = targetused.toString()
+                if (((profile.targetLowMgdl+profile.targetHighMgdl)/2)!= targetused) {
+                    overview_temptarget?.text = Profile.toTargetRangeString(targetused, targetused, Constants.MGDL, units)
                     overview_temptarget?.setTextColor(resourceHelper.gc(R.color.ribbonTextWarning))
                     overview_temptarget?.setBackgroundColor(resourceHelper.gc(R.color.tempTargetBackground))
                 } else {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -657,8 +657,8 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         } else {
             //If the target is not the same as set in the profile then oref has overridden it
             //show this change to the user if it exists
-            if (lastRun != null){
-                var targetused = lastRun!!.constraintsProcessed!!.targetBG
+            var targetused = lastRun?.constraintsProcessed?.targetBG
+            if (targetused != null && targetused != 0.0) {
                 if (units == Constants.MMOL)
                     targetused *= Constants.MGDL_TO_MMOLL
 
@@ -666,12 +666,12 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                     overview_temptarget?.text = targetused.toString()
                     overview_temptarget?.setTextColor(resourceHelper.gc(R.color.ribbonTextWarning))
                     overview_temptarget?.setBackgroundColor(resourceHelper.gc(R.color.tempTargetBackground))
-                }else{
+                } else {
                     overview_temptarget?.setTextColor(resourceHelper.gc(R.color.ribbonTextDefault))
                     overview_temptarget?.setBackgroundColor(resourceHelper.gc(R.color.ribbonDefault))
                     overview_temptarget?.text = Profile.toTargetRangeString(profile.targetLowMgdl, profile.targetHighMgdl, Constants.MGDL, units)
                 }
-            }else {
+            } else {
                 overview_temptarget?.setTextColor(resourceHelper.gc(R.color.ribbonTextDefault))
                 overview_temptarget?.setBackgroundColor(resourceHelper.gc(R.color.ribbonDefault))
                 overview_temptarget?.text = Profile.toTargetRangeString(profile.targetLowMgdl, profile.targetHighMgdl, Constants.MGDL, units)
@@ -696,7 +696,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         if (activeTemp != null)
             overview_basebasal_icon.setImageResource(if (activeTemp.tempBasalConvertedToPercent(System.currentTimeMillis(), profile) > 100) R.drawable.icon_cp_basal_tbr_high else R.drawable.icon_cp_basal_tbr_low)
         else
-            overview_basebasal_icon.setImageResource( R.drawable.icon_cp_basal_no_tbr )
+            overview_basebasal_icon.setImageResource(R.drawable.icon_cp_basal_no_tbr)
 
         // Extended bolus
         val extendedBolus = treatmentsPlugin.getExtendedBolusFromHistory(System.currentTimeMillis())
@@ -777,7 +777,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         // Sensitivity
         if (sp.getBoolean(R.string.key_openapsama_useautosens, false) && constraintChecker.isAutosensModeEnabled().value()) {
             overview_sensitivity_icon.setImageResource(R.drawable.ic_swap_vert_black_48dp_green)
-        }else {
+        } else {
             overview_sensitivity_icon.setImageResource(R.drawable.ic_x_swap_vert_48px_green)
         }
 

--- a/core/src/main/java/info/nightscout/androidaps/data/Profile.java
+++ b/core/src/main/java/info/nightscout/androidaps/data/Profile.java
@@ -523,12 +523,27 @@ public class Profile {
         return ret;
     }
 
+    public double getTargetUnits() {
+        if (units.equals(Constants.MGDL)) {
+            return getTargetMgdl(secondsFromMidnight());
+        } else {
+            return getTargetMmol(secondsFromMidnight());
+        }
+    }
+
     public double getTargetMgdl() {
         return getTargetMgdl(secondsFromMidnight());
     }
 
+    public double getTargetMmol() {
+        return getTargetMmol(secondsFromMidnight());
+    }
+
     public double getTargetMgdl(int timeAsSeconds) {
         return toMgdl((getTargetLowTimeFromMidnight(timeAsSeconds) + getTargetHighTimeFromMidnight(timeAsSeconds)) / 2, units);
+    }
+    public double getTargetMmol(int timeAsSeconds) {
+        return toMmol((getTargetLowTimeFromMidnight(timeAsSeconds) + getTargetHighTimeFromMidnight(timeAsSeconds)) / 2, units);
     }
 
     public double getTargetLowMgdl() {

--- a/core/src/main/java/info/nightscout/androidaps/data/Profile.java
+++ b/core/src/main/java/info/nightscout/androidaps/data/Profile.java
@@ -523,29 +523,13 @@ public class Profile {
         return ret;
     }
 
-    public double getTargetUnits() {
-        if (units.equals(Constants.MGDL)) {
-            return getTargetMgdl(secondsFromMidnight());
-        } else {
-            return getTargetMmol(secondsFromMidnight());
-        }
-    }
-
     public double getTargetMgdl() {
         return getTargetMgdl(secondsFromMidnight());
-    }
-
-    public double getTargetMmol() {
-        return getTargetMmol(secondsFromMidnight());
     }
 
     public double getTargetMgdl(int timeAsSeconds) {
         return toMgdl((getTargetLowTimeFromMidnight(timeAsSeconds) + getTargetHighTimeFromMidnight(timeAsSeconds)) / 2, units);
     }
-    public double getTargetMmol(int timeAsSeconds) {
-        return toMmol((getTargetLowTimeFromMidnight(timeAsSeconds) + getTargetHighTimeFromMidnight(timeAsSeconds)) / 2, units);
-    }
-
     public double getTargetLowMgdl() {
         return toMgdl(getTargetLowTimeFromMidnight(secondsFromMidnight()), units);
     }

--- a/core/src/main/java/info/nightscout/androidaps/plugins/aps/loop/APSResult.java
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/aps/loop/APSResult.java
@@ -62,6 +62,7 @@ public class APSResult {
     public boolean hasPredictions = false;
     public double smb = 0d; // super micro bolus in units
     public long deliverAt = 0;
+    public double targetBG = 0d;
 
     public Constraint<Double> inputConstraints;
 
@@ -184,6 +185,7 @@ public class APSResult {
         newResult.smbConstraint = smbConstraint;
         newResult.percent = percent;
         newResult.usePercent = usePercent;
+        newResult.targetBG = targetBG;
     }
 
 


### PR DESCRIPTION
This PR introduces the ability to show the user when targets have been altered by oref.

In the oref update PR (now merged in dev), we introduced the option for users to turn on options which would make BG targets dynamically adjust. 
These options are sensitvity_raises_target and resistance_lowers_target.

However these internal target changes were not conveyed to the user and can often misinterpret what is actually happening.

This clarifies this by changing the target BG box to green (if another color is preferred let me know and I will update) and shows the oref internally used BG Target.

![Screenshot (21 May 2020 00_15_58)](https://user-images.githubusercontent.com/2896311/82457611-bca28580-9b09-11ea-95c4-f3bfced72871.png)

