### PR TITLE
Bug 2654 (2)

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/comm/MedtronicCommunicationManager.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/comm/MedtronicCommunicationManager.java
@@ -61,14 +61,11 @@ import info.nightscout.androidaps.plugins.pump.medtronic.util.MedtronicUtil;
  */
 public class MedtronicCommunicationManager extends RileyLinkCommunicationManager {
 
-    @Inject AAPSLogger aapsLogger;
     @Inject MedtronicPumpStatus medtronicPumpStatus;
     @Inject MedtronicPumpPlugin medtronicPumpPlugin;
     @Inject MedtronicConverter medtronicConverter;
     @Inject MedtronicUtil medtronicUtil;
     @Inject MedtronicPumpHistoryDecoder medtronicPumpHistoryDecoder;
-    @Inject RileyLinkServiceData rileyLinkServiceData;
-    @Inject ServiceTaskExecutor serviceTaskExecutor;
 
     private final int MAX_COMMAND_TRIES = 3;
     private final int DEFAULT_TIMEOUT = 2000;


### PR DESCRIPTION
- There are few fields hidden between implementations MedtronicCommunicationManager and RileyLinkCommunicationManager. If there is error in packet (if MySentry is configugured on Pump), there is NPE when trying to write to log.