### PR TITLE
BugFix set min SMB frequency number to 3

### DIFF
--- a/app/src/main/res/xml/pref_openapssmb.xml
+++ b/app/src/main/res/xml/pref_openapssmb.xml
@@ -83,7 +83,7 @@
             android:singleLine="true"
             android:title="@string/smbinterval_summary"
             validate:maxNumber="10"
-            validate:minNumber="1"
+            validate:minNumber="3"
             validate:testType="numericRange" />
 
         <info.nightscout.androidaps.utils.textValidator.ValidatingEditTextPreference

--- a/app/src/main/res/xml/pref_openapssmb.xml
+++ b/app/src/main/res/xml/pref_openapssmb.xml
@@ -77,7 +77,7 @@
             android:defaultValue="3"
             android:digits="0123456789"
             android:inputType="number"
-            android:key="key_smbinterval"
+            android:key="@string/key_smbinterval"
             android:maxLines="20"
             android:selectAllOnFocus="true"
             android:singleLine="true"


### PR DESCRIPTION
Since AAPS has a defined limit that will not deliver SMB's less than 3 min apart, there is not point in being able to set a number lower than that as it will not work.  This fixes this.

We can lower this value later when these restrictions can be removed and when more frequently updated CGM delta points become more the normal.