### PR TITLE
Visually Disable SMB preferences based on objectives

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/activities/MyPreferenceFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/MyPreferenceFragment.kt
@@ -333,6 +333,35 @@ class MyPreferenceFragment : PreferenceFragmentCompat(), OnSharedPreferenceChang
                     if (pref != null) pref.isEnabled = true
         }
 
+        if (p.getKey() == resourceHelper.gs(R.string.key_smbinterval) ) {
+            val pref: Preference? = findPreference(resourceHelper.gs(R.string.key_smbinterval))
+            val c =  constraintChecker.isSMBModeEnabled()
+            if (!c.value())
+                if (pref != null) pref.isEnabled = false
+                else
+                    if (pref != null) pref.isEnabled = true
+        }
+
+        if (p.getKey() == resourceHelper.gs(R.string.key_smbmaxminutes) ) {
+            val pref: Preference? = findPreference(resourceHelper.gs(R.string.key_smbmaxminutes))
+            val c =  constraintChecker.isSMBModeEnabled()
+            if (!c.value())
+                if (pref != null) pref.isEnabled = false
+                else
+                    if (pref != null) pref.isEnabled = true
+        }
+
+        if (p.getKey() == resourceHelper.gs(R.string.key_uamsmbmaxminutes) ) {
+            val pref: Preference? = findPreference(resourceHelper.gs(R.string.key_uamsmbmaxminutes))
+            val c =  constraintChecker.isSMBModeEnabled()
+            if (!c.value())
+                if (pref != null) pref.isEnabled = false
+                else
+                    if (pref != null) pref.isEnabled = true
+        }
+
+
+
     }
 
     // We use Preference and custom editor instead of EditTextPreference

--- a/app/src/main/java/info/nightscout/androidaps/activities/MyPreferenceFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/MyPreferenceFragment.kt
@@ -24,6 +24,7 @@ import info.nightscout.androidaps.plugins.bus.RxBusWrapper
 import info.nightscout.androidaps.plugins.configBuilder.PluginStore
 import info.nightscout.androidaps.interfaces.ProfileFunction
 import info.nightscout.androidaps.plugins.constraints.safety.SafetyPlugin
+import info.nightscout.androidaps.plugins.configBuilder.ConstraintChecker
 import info.nightscout.androidaps.plugins.general.automation.AutomationPlugin
 import info.nightscout.androidaps.plugins.general.maintenance.MaintenancePlugin
 import info.nightscout.androidaps.plugins.general.nsclient.NSClientPlugin
@@ -66,6 +67,8 @@ class MyPreferenceFragment : PreferenceFragmentCompat(), OnSharedPreferenceChang
     @Inject lateinit var profileFunction: ProfileFunction
     @Inject lateinit var pluginStore: PluginStore
     @Inject lateinit var config: Config
+
+    @Inject lateinit var constraintChecker: ConstraintChecker
 
     @Inject lateinit var automationPlugin: AutomationPlugin
     @Inject lateinit var danaRPlugin: DanaRPlugin
@@ -312,6 +315,24 @@ class MyPreferenceFragment : PreferenceFragmentCompat(), OnSharedPreferenceChang
         } else {
             updatePrefSummary(p)
         }
+        if (p.getKey() == resourceHelper.gs(R.string.key_use_smb) ) {
+            val pref: Preference? = findPreference(resourceHelper.gs(R.string.key_use_smb))
+            val c =  constraintChecker.isSMBModeEnabled()
+            if (!c.value())
+                if (pref != null) pref.isEnabled = false
+                else
+                    if (pref != null) pref.isEnabled = true
+        }
+
+        if (p.getKey() == resourceHelper.gs(R.string.key_openapsama_useautosens) ) {
+            val pref: Preference? = findPreference(resourceHelper.gs(R.string.key_openapsama_useautosens))
+            val c =  constraintChecker.isAutosensModeEnabled()
+            if (!c.value())
+                if (pref != null) pref.isEnabled = false
+                else
+                    if (pref != null) pref.isEnabled = true
+        }
+
     }
 
     // We use Preference and custom editor instead of EditTextPreference


### PR DESCRIPTION
Visually it can be a bit confusing to people to have the ability to turn preferences on/off even though it doesn't work if the objectives have not passed.

This PR adds the ability to disable/re-enable autosens and SMB preferences based on objectives.

This makes it more clear for the user which things can be set or not.

