### PR TITLE
Add toTimeMinutesFromMidnight to DateUtil

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/utils/DateUtil.java
+++ b/core/src/main/java/info/nightscout/androidaps/utils/DateUtil.java
@@ -151,6 +151,18 @@ public class DateUtil {
         return retval;
     }
 
+    public static long toTimeMinutesFromMidnight(long timeStamp, int minutesFromMidnight) {
+        Calendar c = Calendar.getInstance();
+        c.setTimeInMillis(timeStamp);
+        c.set(Calendar.HOUR_OF_DAY, 0);
+        c.set(Calendar.MINUTE, 0);
+        c.set(Calendar.SECOND, 0);
+        c.set(Calendar.MILLISECOND, 0);
+        long retval = c.getTimeInMillis() + minutesFromMidnight * 60 * 1000L;
+
+        return retval;
+    }
+
     public static String dateString(Date date) {
         DateFormat df = DateFormat.getDateInstance(DateFormat.SHORT);
         return df.format(date);


### PR DESCRIPTION
I propose to add this function to DateUtil (I don't find equivalent in existing function...)
```public static long toTimeMinutesFromMidnight(long timeStamp, int minutesFromMidnight)```
It returns a time offset from midnight the day of timeStamp
i.e. 
```
DateUtil.toTimeMinutesFromMidnight(System.currentTimeMillis(), 120)
```
return a long value for today at 2AM (local time)

I use this function in AutotunePlugin...