### PR TITLE
Constraint IsClosedLoopAllowed -> IsClosedLoopEnabled

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/MainActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/MainActivity.kt
@@ -337,7 +337,7 @@ class MainActivity : NoSplashAppCompatActivity() {
 
     private fun setUserStats() {
         if (!fabricPrivacy.fabricEnabled()) return
-        val closedLoopEnabled = if (constraintChecker.isClosedLoopAllowed().value()) "CLOSED_LOOP_ENABLED" else "CLOSED_LOOP_DISABLED"
+        val closedLoopEnabled = if (constraintChecker.isClosedLoopEnabled().value()) "CLOSED_LOOP_ENABLED" else "CLOSED_LOOP_DISABLED"
         // Size is limited to 36 chars
         val remote = BuildConfig.REMOTE.toLowerCase(Locale.getDefault())
             .replace("https://", "")

--- a/app/src/main/java/info/nightscout/androidaps/plugins/aps/loop/LoopPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/aps/loop/LoopPlugin.java
@@ -292,7 +292,7 @@ public class LoopPlugin extends PluginBase implements LoopInterface {
     }
 
     public boolean isLGS() {
-        Constraint<Boolean> closedLoopEnabled = constraintChecker.isClosedLoopAllowed();
+        Constraint<Boolean> closedLoopEnabled = constraintChecker.isClosedLoopEnabled();
         Double MaxIOBallowed = constraintChecker.getMaxIOBAllowed().value();
         String APSmode = sp.getString(R.string.key_aps_mode, "open");
         PumpInterface pump = activePlugin.getActivePump();
@@ -427,7 +427,7 @@ public class LoopPlugin extends PluginBase implements LoopInterface {
                 return;
             }
 
-            Constraint<Boolean> closedLoopEnabled = constraintChecker.isClosedLoopAllowed();
+            Constraint<Boolean> closedLoopEnabled = constraintChecker.isClosedLoopEnabled();
 
             if (closedLoopEnabled.value()) {
                 if (resultAfterConstraints.isChangeRequested()

--- a/app/src/main/java/info/nightscout/androidaps/plugins/constraints/objectives/ObjectivesPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/constraints/objectives/ObjectivesPlugin.kt
@@ -168,6 +168,10 @@ class ObjectivesPlugin @Inject constructor(
         return value
     }
 
+    override fun isClosedLoopEnabled(value: Constraint<Boolean>): Constraint<Boolean> {
+        return this.isClosedLoopAllowed(value);
+    }
+
     override fun isAutosensModeEnabled(value: Constraint<Boolean>): Constraint<Boolean> {
         if (!objectives[AUTOSENS_OBJECTIVE].isStarted)
             value.set(aapsLogger, false, String.format(resourceHelper.gs(R.string.objectivenotstarted), AUTOSENS_OBJECTIVE + 1), this)

--- a/app/src/main/java/info/nightscout/androidaps/plugins/constraints/objectives/objectives/Objective5.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/constraints/objectives/objectives/Objective5.java
@@ -24,7 +24,7 @@ public class Objective5 extends Objective {
             @Override
             public boolean isCompleted() {
                 Constraint<Boolean> closedLoopEnabled = new Constraint<>(true);
-                safetyPlugin.isClosedLoopAllowed(closedLoopEnabled);
+                safetyPlugin.isClosedLoopEnabled(closedLoopEnabled);
                 return closedLoopEnabled.value();
             }
         });

--- a/app/src/main/java/info/nightscout/androidaps/plugins/constraints/safety/SafetyPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/constraints/safety/SafetyPlugin.java
@@ -104,9 +104,7 @@ public class SafetyPlugin extends PluginBase implements ConstraintsInterface {
         if ((mode.equals("open")))
             value.set(getAapsLogger(), false, getResourceHelper().gs(R.string.closedmodedisabledinpreferences), this);
 
-        value = this.isClosedLoopAllowed(value);
-
-        return value;
+        return this.isClosedLoopAllowed(value);
 
     }
 
@@ -141,7 +139,7 @@ public class SafetyPlugin extends PluginBase implements ConstraintsInterface {
         boolean enabled = sp.getBoolean(R.string.key_use_smb, false);
         if (!enabled)
             value.set(getAapsLogger(), false, getResourceHelper().gs(R.string.smbdisabledinpreferences), this);
-        Constraint<Boolean> closedLoop = constraintChecker.isClosedLoopAllowed();
+        Constraint<Boolean> closedLoop = constraintChecker.isClosedLoopEnabled();
         if (!closedLoop.value())
             value.set(getAapsLogger(), false, getResourceHelper().gs(R.string.smbnotallowedinopenloopmode), this);
         return value;

--- a/app/src/main/java/info/nightscout/androidaps/plugins/constraints/safety/SafetyPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/constraints/safety/SafetyPlugin.java
@@ -99,10 +99,20 @@ public class SafetyPlugin extends PluginBase implements ConstraintsInterface {
     }
 
     @NonNull @Override
-    public Constraint<Boolean> isClosedLoopAllowed(@NonNull Constraint<Boolean> value) {
+    public Constraint<Boolean> isClosedLoopEnabled(@NonNull Constraint<Boolean> value) {
         String mode = sp.getString(R.string.key_aps_mode, "open");
         if ((mode.equals("open")))
             value.set(getAapsLogger(), false, getResourceHelper().gs(R.string.closedmodedisabledinpreferences), this);
+
+        value = this.isClosedLoopAllowed(value);
+
+        return value;
+
+    }
+
+    @NonNull @Override
+    public Constraint<Boolean> isClosedLoopAllowed(@NonNull Constraint<Boolean> value) {
+        String mode = sp.getString(R.string.key_aps_mode, "open");
 
         if (!buildHelper.isEngineeringModeOrRelease()) {
             if (value.value()) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/constraints/storage/StorageConstraintPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/constraints/storage/StorageConstraintPlugin.kt
@@ -48,6 +48,10 @@ open class StorageConstraintPlugin @Inject constructor(
         return value
     }
 
+    override fun isClosedLoopEnabled(value: Constraint<Boolean>): Constraint<Boolean> {
+        return this.isClosedLoopAllowed(value)
+    }
+
     open fun availableInternalMemorySize(): Long {
         val path = Environment.getDataDirectory()
         val stat = StatFs(path.path)

--- a/app/src/main/java/info/nightscout/androidaps/plugins/constraints/versionChecker/VersionCheckerPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/constraints/versionChecker/VersionCheckerPlugin.kt
@@ -63,6 +63,10 @@ class VersionCheckerPlugin @Inject constructor(
             value
     }
 
+    override fun isClosedLoopEnabled(value: Constraint<Boolean>): Constraint<Boolean> {
+        return this.isClosedLoopAllowed(value)
+    }
+
     private fun checkWarning() {
         val now = System.currentTimeMillis()
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -441,7 +441,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
 
         // **** Temp button ****
         val lastRun = loopPlugin.lastRun
-        val closedLoopEnabled = constraintChecker.isClosedLoopAllowed()
+        val closedLoopEnabled = constraintChecker.isClosedLoopEnabled()
 
         val showAcceptButton = !closedLoopEnabled.value() && // Open mode needed
             lastRun != null &&
@@ -584,7 +584,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
             overview_timeagoshort?.text = "(" + DateUtil.minAgoShort(lastBG.date) + ")"
 
         }
-        val closedLoopEnabled = constraintChecker.isClosedLoopAllowed()
+        val closedLoopEnabled = constraintChecker.isClosedLoopEnabled()
 
         // open loop mode
         if (config.APS && pump.pumpDescription.isTempBasalCapable) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/ActionStringHandler.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/ActionStringHandler.kt
@@ -402,7 +402,7 @@ class ActionStringHandler @Inject constructor(
             var ret = ""
             // decide if enabled/disabled closed/open; what Plugin as APS?
             if (loopPlugin.isEnabled(loopPlugin.getType())) {
-                ret += if (constraintChecker.isClosedLoopAllowed().value()) {
+                ret += if (constraintChecker.isClosedLoopEnabled().value()) {
                     "CLOSED LOOP\n"
                 } else {
                     "OPEN LOOP\n"

--- a/app/src/test/java/info/nightscout/androidaps/interfaces/ConstraintsCheckerTest.kt
+++ b/app/src/test/java/info/nightscout/androidaps/interfaces/ConstraintsCheckerTest.kt
@@ -150,14 +150,14 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
     // Safety & Objectives
     // 2x Safety & Objectives
     @Test
-    fun isClosedLoopAllowedTest() {
+    fun isClosedLoopEnabledTest() {
         `when`(sp.getString(R.string.key_aps_mode, "open")).thenReturn("closed")
         objectivesPlugin.objectives[ObjectivesPlugin.MAXIOB_ZERO_CL_OBJECTIVE].startedOn = 0
-        var c: Constraint<Boolean> = constraintChecker.isClosedLoopAllowed()
+        var c: Constraint<Boolean> = constraintChecker.isClosedLoopEnabled()
         Assert.assertEquals(true, c.reasonList.size == 2) // Safety & Objectives
         Assert.assertEquals(false, c.value())
         `when`(sp.getString(R.string.key_aps_mode, "open")).thenReturn("open")
-        c = constraintChecker.isClosedLoopAllowed()
+        c = constraintChecker.isClosedLoopEnabled()
         Assert.assertEquals(true, c.reasonList.size == 3) // 2x Safety & Objectives
         Assert.assertEquals(false, c.value())
     }

--- a/app/src/test/java/info/nightscout/androidaps/plugins/aps/loop/APSResultTest.kt
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/aps/loop/APSResultTest.kt
@@ -193,7 +193,7 @@ class APSResultTest : TestBaseWithProfile() {
 
     @Before
     fun prepare() {
-        `when`(constraintChecker.isClosedLoopAllowed()).thenReturn(closedLoopEnabled)
+        `when`(constraintChecker.isClosedLoopEnabled()).thenReturn(closedLoopEnabled)
         `when`(activePluginProvider.activePump).thenReturn(virtualPumpPlugin)
         `when`(sp.getDouble(ArgumentMatchers.anyInt(), ArgumentMatchers.anyDouble())).thenReturn(30.0)
         `when`(virtualPumpPlugin.pumpDescription).thenReturn(pumpDescription)

--- a/app/src/test/java/info/nightscout/androidaps/plugins/constraints/objectives/ObjectivesPluginTest.kt
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/constraints/objectives/ObjectivesPluginTest.kt
@@ -55,7 +55,7 @@ class ObjectivesPluginTest : TestBase() {
     @Test fun notStartedObjective6ShouldLimitClosedLoop() {
         objectivesPlugin.objectives[ObjectivesPlugin.MAXIOB_ZERO_CL_OBJECTIVE].startedOn = 0
         var c = Constraint(true)
-        c = objectivesPlugin.isClosedLoopAllowed(c)
+        c = objectivesPlugin.isClosedLoopEnabled(c)
         Assert.assertEquals(true, c.getReasons(aapsLogger).contains("Objective 6 not started"))
         Assert.assertEquals(false, c.value())
     }

--- a/app/src/test/java/info/nightscout/androidaps/plugins/constraints/safety/SafetyPluginTest.kt
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/constraints/safety/SafetyPluginTest.kt
@@ -91,7 +91,7 @@ class SafetyPluginTest : TestBaseWithProfile() {
         `when`(sp.getString(R.string.key_aps_mode, "open")).thenReturn("closed")
         `when`(buildHelper.isEngineeringModeOrRelease()).thenReturn(false)
         var c = Constraint(true)
-        c = safetyPlugin.isClosedLoopAllowed(c)
+        c = safetyPlugin.isClosedLoopEnabled(c)
         Assert.assertTrue(c.getReasons(aapsLogger).contains("Running dev version. Closed loop is disabled."))
         Assert.assertEquals(false, c.value())
     }
@@ -99,7 +99,7 @@ class SafetyPluginTest : TestBaseWithProfile() {
     @Test fun setOpenLoopInPreferencesShouldLimitClosedLoop() {
         `when`(sp.getString(R.string.key_aps_mode, "open")).thenReturn("open")
         var c = Constraint(true)
-        c = safetyPlugin.isClosedLoopAllowed(c)
+        c = safetyPlugin.isClosedLoopEnabled(c)
         Assert.assertTrue(c.getReasons(aapsLogger).contains("Closed loop mode disabled in preferences"))
         Assert.assertEquals(false, c.value())
     }

--- a/app/src/test/java/info/nightscout/androidaps/plugins/constraints/storage/StorageConstraintPluginTest.kt
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/constraints/storage/StorageConstraintPluginTest.kt
@@ -44,9 +44,9 @@ class StorageConstraintPluginTest : TestBase() {
         val mocked = MockedStorageConstraintPlugin(HasAndroidInjector { AndroidInjector { } }, aapsLogger, resourceHelper, rxBusWrapper)
         // Set free space under 200(Mb) to disable loop
         mocked.memSize = 150L
-        Assert.assertEquals(false, mocked.isClosedLoopAllowed(Constraint(true)).value())
+        Assert.assertEquals(false, mocked.isClosedLoopEnabled(Constraint(true)).value())
         // Set free space over 200(Mb) to enable loop
         mocked.memSize = 300L
-        Assert.assertEquals(true, mocked.isClosedLoopAllowed(Constraint(true)).value())
+        Assert.assertEquals(true, mocked.isClosedLoopEnabled(Constraint(true)).value())
     }
 }

--- a/core/src/main/java/info/nightscout/androidaps/interfaces/ConstraintsInterface.kt
+++ b/core/src/main/java/info/nightscout/androidaps/interfaces/ConstraintsInterface.kt
@@ -18,6 +18,11 @@ interface ConstraintsInterface {
     }
 
     @JvmDefault
+    fun isClosedLoopEnabled(value: Constraint<Boolean>): Constraint<Boolean> {
+        return value
+    }
+
+    @JvmDefault
     fun isAutosensModeEnabled(value: Constraint<Boolean>): Constraint<Boolean> {
         return value
     }

--- a/core/src/main/java/info/nightscout/androidaps/plugins/aps/loop/APSResult.java
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/aps/loop/APSResult.java
@@ -301,7 +301,7 @@ public class APSResult {
     }
 
     public boolean isChangeRequested() {
-        Constraint<Boolean> closedLoopEnabled = constraintChecker.isClosedLoopAllowed();
+        Constraint<Boolean> closedLoopEnabled = constraintChecker.isClosedLoopEnabled();
         // closed loop mode: handle change at driver level
         if (closedLoopEnabled.value()) {
             aapsLogger.debug(LTag.APS, "DEFAULT: Closed mode");

--- a/core/src/main/java/info/nightscout/androidaps/plugins/configBuilder/ConstraintChecker.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/configBuilder/ConstraintChecker.kt
@@ -18,6 +18,9 @@ class ConstraintChecker @Inject constructor(private val activePlugin: ActivePlug
     fun isClosedLoopAllowed(): Constraint<Boolean> =
         isClosedLoopAllowed(Constraint(true))
 
+    fun isClosedLoopEnabled(): Constraint<Boolean> =
+        isClosedLoopEnabled(Constraint(true))
+
     fun isAutosensModeEnabled(): Constraint<Boolean> =
         isAutosensModeEnabled(Constraint(true))
 
@@ -63,6 +66,16 @@ class ConstraintChecker @Inject constructor(private val activePlugin: ActivePlug
             val constraint = p as ConstraintsInterface
             if (!p.isEnabled(PluginType.CONSTRAINTS)) continue
             constraint.isLoopInvocationAllowed(value)
+        }
+        return value
+    }
+
+    override fun isClosedLoopEnabled(value: Constraint<Boolean>): Constraint<Boolean> {
+        val constraintsPlugins = activePlugin.getSpecificPluginsListByInterface(ConstraintsInterface::class.java)
+        for (p in constraintsPlugins) {
+            val constraint = p as ConstraintsInterface
+            if (!p.isEnabled(PluginType.CONSTRAINTS)) continue
+            constraint.isClosedLoopEnabled(value)
         }
         return value
     }


### PR DESCRIPTION
PR to allow the following constraints `IsClosedLoopAllowed` to `IsClosedLoopEnabled` follow what they say.

Implementation:  `IsClosedLoopAllowed` Every existing check that used `IsClosedLoopEnabled` previously minus preference checking.
`IsClosedLoopEnabled` same constraints as `IsClosedLoopAllowed` plus checking/using if the closed loop preference as a constraint.

This allows the `IsClosedLoopAllowed` constraint to see if a user is eligible for closed loop.



