### PR TITLE
Clean double string names

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/constraints/objectives/objectives/Objective2.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/constraints/objectives/objectives/Objective2.java
@@ -19,7 +19,7 @@ public class Objective2 extends Objective {
 
     @Override
     protected void setupTasks(List<Task> tasks) {
-        tasks.add(new ExamTask(R.string.dia_label, R.string.dia_whatmeansdia,"dia")
+        tasks.add(new ExamTask(R.string.dia_label_exam, R.string.dia_whatmeansdia,"dia")
                 .option(new Option(R.string.dia_minimumis3h, false))
                 .option(new Option(R.string.dia_minimumis5h, true))
                 .option(new Option(R.string.dia_meaningisequaltodiapump, false))
@@ -160,7 +160,7 @@ public class Objective2 extends Objective {
                 .option(new Option(R.string.nsclient_spikeiphone, true))
                 .hint(new Hint(R.string.nsclient_hint1))
         );
-        tasks.add(new ExamTask(R.string.isf_label, R.string.whatistrue,"isf")
+        tasks.add(new ExamTask(R.string.isf_label_exam, R.string.whatistrue,"isf")
                 .option(new Option(R.string.isf_increasingvalue, true))
                 .option(new Option(R.string.isf_decreasingvalue, false))
                 .option(new Option(R.string.isf_noeffect, false))
@@ -169,7 +169,7 @@ public class Objective2 extends Objective {
                 .hint(new Hint(R.string.isf_hint1))
                 .hint(new Hint(R.string.isf_hint2))
         );
-        tasks.add(new ExamTask(R.string.ic_label, R.string.whatistrue,"ic")
+        tasks.add(new ExamTask(R.string.ic_label_exam, R.string.whatistrue,"ic")
                 .option(new Option(R.string.ic_increasingvalue, true))
                 .option(new Option(R.string.ic_decreasingvalue, false))
                 .option(new Option(R.string.ic_noeffect, false))

--- a/app/src/main/res/layout/survey_activity.xml
+++ b/app/src/main/res/layout/survey_activity.xml
@@ -73,7 +73,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="10dp"
                     android:labelFor="@+id/survey_weight"
-                    android:text="@string/weight"
+                    android:text="@string/weight_label"
                     android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
                 <EditText

--- a/app/src/main/res/values/exam.xml
+++ b/app/src/main/res/values/exam.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="dia_whatmeansdia">What is true about DIA?</string>
-    <string name="dia_label">Topic: Duration of Insulin Action</string>
+    <string name="dia_label_exam">Topic: Duration of Insulin Action</string>
     <string name="dia_minimumis3h">The minimum value is 3 hours.</string>
     <string name="dia_minimumis5h">The minimum value is 5 hours.</string>
     <string name="dia_hint1">https://androidaps.readthedocs.io/en/latest/EN/Configuration/Config-Builder.html?#insulin</string>
@@ -122,7 +122,7 @@
     <string name="nsclient_looponiphone">Loop app on iPhone.</string>
     <string name="nsclient_spikeiphone">Spike app on iPhone.</string>
     <string name="nsclient_hint1">https://androidaps.readthedocs.io/en/latest/EN/Children/Children.html</string>
-    <string name="isf_label">Topic: Insulin Sensitivity Factor</string>
+    <string name="isf_label_exam">Topic: Insulin Sensitivity Factor</string>
     <string name="isf_increasingvalue">Higher ISF values lead to less insulin delivery when AAPS corrects for high BG.</string>
     <string name="isf_decreasingvalue">Lower ISF values lead to less insulin delivery when AAPS corrects for high BG.</string>
     <string name="isf_noeffect">Changing ISF values has no effect on the amount of insulin delivered when AAPS corrects for high BG.</string>
@@ -130,7 +130,7 @@
     <string name="isf_profile">Changing the ISF value in your profile is enough to apply the change.</string>
     <string name="isf_hint1">https://androidaps.readthedocs.io/en/latest/EN/Getting-Started/FAQ.html#insulin-sensitivity-factor-isf-mmol-l-u-or-mg-dl-u</string>
     <string name="isf_hint2">https://androidaps.readthedocs.io/en/latest/EN/Usage/Profiles.html</string>
-    <string name="ic_label">Topic: The IC Ratio</string>
+    <string name="ic_label_exam">Topic: The IC Ratio</string>
     <string name="ic_increasingvalue">Higher IC ratios lead to less insulin delivered for a given amount of carbs.</string>
     <string name="ic_decreasingvalue">Lower IC ratios lead to less insulin delivered for a given amount of carbs.</string>
     <string name="ic_noeffect">If you have 0 COB, changing the IC ratio will lead to a different amount of insulin to correct a given BG value.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,8 +135,6 @@
     <string name="loop_constraintsprocessed_label">After processed constraints</string>
     <string name="loop_tbrsetbypump_label">Temp basal set by pump</string>
     <string name="openapsma_lastenact_label">Last enacted</string>
-    <string name="ok">OK</string>
-    <string name="cancel">Cancel</string>
     <string name="noapsselected">NO APS SELECTED OR PROVIDED RESULT</string>
     <string name="safety">Safety</string>
     <string name="openapsma_disabled">Plugin is disabled</string>
@@ -147,8 +145,6 @@
     <string name="overview_treatment_label">Treatment</string>
     <string name="overview_calculator_label">Calculator</string>
     <string name="constraintapllied">Constraint applied!</string>
-    <string name="confirmation">Confirmation</string>
-    <string name="bolus">Bolus</string>
     <string name="sms_bolus">Bolus:</string>
     <string name="basal">Basal</string>
     <string name="sms_basal">Basal:</string>
@@ -1471,7 +1467,6 @@
     <string name="invalidweight">Invalid weight entry</string>
     <string name="tirformat"><![CDATA[<b>%1$s:</b> Low: <b>%2$02d%%</b> In: <b>%3$02d%%</b> High: <b>%4$02d%%</b>]]></string>
     <string name="average">Average</string>
-    <string name="tdd">TDD</string>
     <string name="tir">TIR</string>
     <string name="activitymonitor">Activity monitor</string>
     <string name="doyouwantresetstats">Do you want to reset activity stats?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1158,7 +1158,6 @@
     <string name="recurringTime">Recurring time</string>
     <string name="every">Every</string>
     <string name="never">Never</string>
-    <string name="mins">%1$dmins</string>
     <string name="condition">Condition:</string>
     <string name="action">Action:</string>
     <string name="iob_u">IOB [U]:</string>
@@ -1457,7 +1456,7 @@
     <string name="reorder_label">Reorder</string>
 
     <string name="age">Age:</string>
-    <string name="weight">Weight:</string>
+    <string name="weight_label">Weight:</string>
     <string name="id">ID:</string>
     <string name="submit">Submit</string>
     <string name="mostcommonprofile">Most common profile:</string>


### PR DESCRIPTION
I deleted some of them and renamed others to keep both strings
The only different string with same name I deleted is "mins"
app/strings: ```<string name="mins">%1$dmins</string>``` => deleted
core/strings: ```<string name="mins">%1$dmin</string>```