### PR TITLE
[2.6.7] Send correct SGV history data to WearOS when mmol/L is used

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
@@ -323,7 +323,7 @@ public class WatchUpdaterService extends WearableListenerService implements Goog
             dataMap.putString("avgDelta", deltastring(glucoseStatus.avgdelta, glucoseStatus.avgdelta * Constants.MGDL_TO_MMOLL, units));
         }
         dataMap.putLong("sgvLevel", sgvLevel);
-        dataMap.putDouble("sgvDouble", lastBG.value);
+        dataMap.putDouble("sgvDouble", lastBG.valueToUnits(units));
         dataMap.putDouble("high", highLine);
         dataMap.putDouble("low", lowLine);
         return dataMap;


### PR DESCRIPTION
Fix for Issue #2718 

Raw SGV (mg/dL) double values were sent (as part of SGV history) to WearOS, irregardless of user unit settings, resulting in incorrect rendering of SGV graph on WearOS watchfaces when mmol/L was used.

This one-liner fix send converted values to WearOS

**before:**
![device-2020-06-17-145147](https://user-images.githubusercontent.com/5094588/84903095-f38a9d80-b0ad-11ea-96e0-901bcd34e366.png)

**after:**
![device-2020-06-17-150828](https://user-images.githubusercontent.com/5094588/84903112-f9807e80-b0ad-11ea-8c73-42c84e0d9e18.png)


