### PR TITLE
[2.6.7] Send correct SGV prediction data to WearOS when mmol/L is used

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
@@ -536,9 +536,10 @@ public class WatchUpdaterService extends WearableListenerService implements Goog
             List<BgReading> predArray = finalLastRun.getConstraintsProcessed().getPredictions();
 
             if (!predArray.isEmpty()) {
+                final String units = profileFunction.getUnits();
                 for (BgReading bg : predArray) {
                     if (bg.value < 40) continue;
-                    predictions.add(predictionMap(bg.date, bg.value, bg.getPredectionColor()));
+                    predictions.add(predictionMap(bg.date, bg.valueToUnits(units), bg.getPredectionColor()));
                 }
             }
         }


### PR DESCRIPTION
Follow up for #2728 PR to fix #2718, this time for **predictions** SGV values, same issue but buried in different part of WatchUpdaterService