### PR TITLE
WEAR Second Fix, send all raw values in mg/dl 

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
@@ -298,14 +298,16 @@ public class WatchUpdaterService extends WearableListenerService implements Goog
 
     private DataMap dataMapSingleBG(BgReading lastBG, GlucoseStatus glucoseStatus) {
         String units = profileFunction.getUnits();
-
-        double lowLine = defaultValueHelper.determineLowLine();
-        double highLine = defaultValueHelper.determineHighLine();
+        double convert2MGDL = 1.0;
+        if (units.equals(Constants.MMOL))
+            convert2MGDL = Constants.MMOLL_TO_MGDL;
+        double lowLine = defaultValueHelper.determineLowLine()*convert2MGDL;
+        double highLine = defaultValueHelper.determineHighLine()*convert2MGDL;
 
         long sgvLevel = 0L;
-        if (lastBG.valueToUnits(units) > highLine) {
+        if (lastBG.value > highLine) {
             sgvLevel = 1;
-        } else if (lastBG.valueToUnits(units) < lowLine) {
+        } else if (lastBG.value < lowLine) {
             sgvLevel = -1;
         }
 
@@ -323,7 +325,7 @@ public class WatchUpdaterService extends WearableListenerService implements Goog
             dataMap.putString("avgDelta", deltastring(glucoseStatus.avgdelta, glucoseStatus.avgdelta * Constants.MGDL_TO_MMOLL, units));
         }
         dataMap.putLong("sgvLevel", sgvLevel);
-        dataMap.putDouble("sgvDouble", lastBG.valueToUnits(units));
+        dataMap.putDouble("sgvDouble", lastBG.value);
         dataMap.putDouble("high", highLine);
         dataMap.putDouble("low", lowLine);
         return dataMap;

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
@@ -541,7 +541,7 @@ public class WatchUpdaterService extends WearableListenerService implements Goog
                 final String units = profileFunction.getUnits();
                 for (BgReading bg : predArray) {
                     if (bg.value < 40) continue;
-                    predictions.add(predictionMap(bg.date, bg.valueToUnits(units), bg.getPredectionColor()));
+                    predictions.add(predictionMap(bg.date, bg.value, bg.getPredectionColor()));
                 }
             }
         }

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/BgGraphBuilder.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/BgGraphBuilder.java
@@ -396,8 +396,8 @@ public class BgGraphBuilder {
         if(singleLine) {
             for (BgWatchData bgReading : bgDataList) {
                 if(bgReading.timestamp > start_time) {
-                    if (bgReading.sgv >= 400) {
-                        inRangeValues.add(new PointValue(fuzz(bgReading.timestamp), (float) 400));
+                    if (bgReading.sgv >= 450) {
+                        inRangeValues.add(new PointValue(fuzz(bgReading.timestamp), (float) 450));
                     } else if (bgReading.sgv >= highMark) {
                         inRangeValues.add(new PointValue(fuzz(bgReading.timestamp), (float) bgReading.sgv));
                     } else if (bgReading.sgv >= lowMark) {
@@ -412,8 +412,8 @@ public class BgGraphBuilder {
         } else {
             for (BgWatchData bgReading : bgDataList) {
                 if (bgReading.timestamp > start_time) {
-                    if (bgReading.sgv >= 400) {
-                        highValues.add(new PointValue(fuzz(bgReading.timestamp), (float) 400));
+                    if (bgReading.sgv >= 450) {
+                        highValues.add(new PointValue(fuzz(bgReading.timestamp), (float) 450));
                     } else if (bgReading.sgv >= highMark) {
                         highValues.add(new PointValue(fuzz(bgReading.timestamp), (float) bgReading.sgv));
                     } else if (bgReading.sgv >= lowMark) {


### PR DESCRIPTION
Includes BG values (svg), lowline and highline. because it's hard coded in mg/dl in Wear

I included a minor improvement in Wear code (just increase a little bit highest BG value in graphs, 400 mg/dl is sometimes too low => updated to 450 mg/dl)

Fix issue https://github.com/MilosKozak/AndroidAPS/issues/2771