### PR TITLE
Carbs Required Fixes

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -748,13 +748,16 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
 
         if (config.APS && lastRun?.constraintsProcessed != null) {
             if (lastRun.constraintsProcessed!!.carbsReq > 0) {
-                overview_cob?.text = cobText + " | " + lastRun.constraintsProcessed!!.carbsReq + " " + resourceHelper.gs(R.string.required)
+                //only display carbsreq when carbs havnt been entered recently
+                if (treatmentsPlugin.lastCarbTime < lastRun.lastAPSRun){
+                    cobText = cobText + " | " + lastRun.constraintsProcessed!!.carbsReq + " " + resourceHelper.gs(R.string.required)
+                }
+                overview_cob?.text = cobText
                 if (!carbAnimation.isRunning)
                     carbAnimation.start()
             } else {
                 overview_cob?.text = cobText
-                if (carbAnimation.isRunning)
-                    carbAnimation.stop()
+                carbAnimation.stop()
                 carbAnimation.selectDrawable(0);
             }
         }


### PR DESCRIPTION
This PR fixes some outstanding issues in Dev and 2.7 Beta1 in regards to Carbs Required Integration into AAPS.

The Carb Icon will now properly stop pulsing red, once carbs are no longer needed (without needing to swipe screens)

Local Carbs Required Notifications (non Android) will now be automatically dismissed when carbs are no longer needed.

Fixing of Double Notifications on Wear OS when carbs are required. - This may need further testing to see if it has been fully fixed.

Carbs req will not be shown on the main overview screen if a carb treatment has been made since the last run of APS. (The carb icon will still pulse red to state more carbs may be needed soon but will stop when none are actually needed)

I am happy for this to be merged immediately, I will continue testing on this follow up again (and issue another PR if needed) if the WearOS Double carbs notification is still not fixed.

This closes #2761 