### PR TITLE
Fix: Green Glucose Target override 

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -655,7 +655,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
             // If the target is not the same as set in the profile then oref has overridden it
             val targetUsed = lastRun?.constraintsProcessed?.targetBG ?: 0.0
 
-            if (targetUsed != 0.0 && profile.targetMgdl != targetUsed) {
+            if (targetUsed != 0.0 && abs(profile.targetMgdl-targetUsed) > 0.01) {
                 aapsLogger.debug("Adjusted target. Profile: ${profile.targetMgdl} APS: $targetUsed")
                 overview_temptarget?.text = Profile.toTargetRangeString(targetUsed, targetUsed, Constants.MGDL, units)
                 overview_temptarget?.setTextColor(resourceHelper.gc(R.color.ribbonTextWarning))


### PR DESCRIPTION
Closes: #2788 

Reason: Profile Glucose when using 2 values (lower and higher) uses double precision and gets a middle value between the two value. The means lots of .000000001s on occasions which means it was failing the comparison test.

The Fix: Use maths abs function to find if the diff is bigger than 0.01 instead, alternative options to the fix is clamp the profile target glucose to 1 dp.

 