### PR TITLE
Fix defaultprofile and compareprofile units

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/data/defaultProfile/DefaultProfile.kt
+++ b/core/src/main/java/info/nightscout/androidaps/data/defaultProfile/DefaultProfile.kt
@@ -26,21 +26,21 @@ class DefaultProfile @Inject constructor(val injector: HasAndroidInjector) {
             val ic = Round.roundTo(250.0 / _tdd, 1.0)
             profile.put("carbratio", singleValueArray(ic, arrayOf(0.0, -4.0, -1.0, -2.0, -4.0, 0.0, -4.0)))
             val isf = Round.roundTo(200.0 / _tdd, 0.1)
-            profile.put("sens", singleValueArray(isf, arrayOf(0.0, -2.0, -0.0, -0.0, -2.0, 0.0, -2.0)))
+            profile.put("sens", singleValueArrayFromMmolToUnits(isf, arrayOf(0.0, -2.0, -0.0, -0.0, -2.0, 0.0, -2.0),units))
         } else if (age >= 6 && age < 12) {
             val _tdd = if (tdd == 0.0) 0.8 * weight else tdd
             closest(sixToEleven, _tdd * 0.4)?.let { array -> profile.put("basal", arrayToJson(array)) }
             val ic = Round.roundTo(375.0 / _tdd, 1.0)
             profile.put("carbratio", singleValueArray(ic, arrayOf(0.0, -3.0, 0.0, -1.0, -3.0, 0.0, -2.0)))
             val isf = Round.roundTo(170.0 / _tdd, 0.1)
-            profile.put("sens", singleValueArray(isf, arrayOf(0.0, -1.0, -0.0, -0.0, -1.0, 0.0, -1.0)))
+            profile.put("sens", singleValueArrayFromMmolToUnits(isf, arrayOf(0.0, -1.0, -0.0, -0.0, -1.0, 0.0, -1.0),units))
         } else if (age >= 12 && age < 18) {
             val _tdd = if (tdd == 0.0) 1.0 * weight else tdd
             closest(twelveToSeventeen, _tdd * 0.5)?.let { array -> profile.put("basal", arrayToJson(array)) }
             val ic = Round.roundTo(500.0 / _tdd, 1.0)
             profile.put("carbratio", singleValueArray(ic, arrayOf(0.0, -1.0, 0.0, 0.0, -1.0, 0.0, -1.0)))
             val isf = Round.roundTo(100.0 / _tdd, 0.1)
-            profile.put("sens", singleValueArray(isf, arrayOf(0.2, 0.0, 0.2, 0.2, 0.0, 0.2, 0.2)))
+            profile.put("sens", singleValueArrayFromMmolToUnits(isf, arrayOf(0.2, 0.0, 0.2, 0.2, 0.0, 0.2, 0.2),units))
         } else if (age >= 18) {
 
         }
@@ -146,6 +146,18 @@ class DefaultProfile @Inject constructor(val injector: HasAndroidInjector) {
         array.put(JSONObject().put("time", "14:00").put("value", value + sample[4]))
         array.put(JSONObject().put("time", "16:00").put("value", value + sample[5]))
         array.put(JSONObject().put("time", "19:00").put("value", value + sample[6]))
+        return array
+    }
+
+    private fun singleValueArrayFromMmolToUnits(value: Double, sample: Array<Double>, units: String): JSONArray {
+        val array = JSONArray()
+        array.put(JSONObject().put("time", "00:00").put("value", Profile.fromMmolToUnits(value + sample[0],units)))
+        array.put(JSONObject().put("time", "06:00").put("value", Profile.fromMmolToUnits(value + sample[1],units)))
+        array.put(JSONObject().put("time", "09:00").put("value", Profile.fromMmolToUnits(value + sample[2],units)))
+        array.put(JSONObject().put("time", "11:00").put("value", Profile.fromMmolToUnits(value + sample[3],units)))
+        array.put(JSONObject().put("time", "14:00").put("value", Profile.fromMmolToUnits(value + sample[4],units)))
+        array.put(JSONObject().put("time", "16:00").put("value", Profile.fromMmolToUnits(value + sample[5],units)))
+        array.put(JSONObject().put("time", "19:00").put("value", Profile.fromMmolToUnits(value + sample[6],units)))
         return array
     }
 }

--- a/core/src/main/java/info/nightscout/androidaps/data/defaultProfile/DefaultProfile.kt
+++ b/core/src/main/java/info/nightscout/androidaps/data/defaultProfile/DefaultProfile.kt
@@ -1,7 +1,6 @@
 package info.nightscout.androidaps.data.defaultProfile
 
 import dagger.android.HasAndroidInjector
-import info.nightscout.androidaps.Constants
 import info.nightscout.androidaps.data.Profile
 import info.nightscout.androidaps.utils.Round
 import org.json.JSONArray

--- a/core/src/main/java/info/nightscout/androidaps/data/defaultProfile/DefaultProfile.kt
+++ b/core/src/main/java/info/nightscout/androidaps/data/defaultProfile/DefaultProfile.kt
@@ -34,7 +34,7 @@ class DefaultProfile @Inject constructor(val injector: HasAndroidInjector) {
             profile.put("carbratio", singleValueArray(ic, arrayOf(0.0, -3.0, 0.0, -1.0, -3.0, 0.0, -2.0)))
             val isf = Round.roundTo(170.0 / _tdd, 0.1)
             profile.put("sens", singleValueArray(isf, arrayOf(0.0, -1.0, -0.0, -0.0, -1.0, 0.0, -1.0)))
-        } else if (age >= 12 && age < 17) {
+        } else if (age >= 12 && age < 18) {
             val _tdd = if (tdd == 0.0) 1.0 * weight else tdd
             closest(twelveToSeventeen, _tdd * 0.5)?.let { array -> profile.put("basal", arrayToJson(array)) }
             val ic = Round.roundTo(500.0 / _tdd, 1.0)

--- a/core/src/main/java/info/nightscout/androidaps/data/defaultProfile/DefaultProfile.kt
+++ b/core/src/main/java/info/nightscout/androidaps/data/defaultProfile/DefaultProfile.kt
@@ -1,6 +1,7 @@
 package info.nightscout.androidaps.data.defaultProfile
 
 import dagger.android.HasAndroidInjector
+import info.nightscout.androidaps.Constants
 import info.nightscout.androidaps.data.Profile
 import info.nightscout.androidaps.utils.Round
 import org.json.JSONArray
@@ -49,6 +50,7 @@ class DefaultProfile @Inject constructor(val injector: HasAndroidInjector) {
         profile.put("timezone", TimeZone.getDefault().getID())
         profile.put("target_high", JSONArray().put(JSONObject().put("time", "00:00").put("value", Profile.fromMgdlToUnits(108.0, units))))
         profile.put("target_low", JSONArray().put(JSONObject().put("time", "00:00").put("value", Profile.fromMgdlToUnits(108.0, units))))
+        profile.put("units", units)
         return Profile(injector, profile, units)
     }
 

--- a/core/src/main/java/info/nightscout/androidaps/dialogs/ProfileViewerDialog.kt
+++ b/core/src/main/java/info/nightscout/androidaps/dialogs/ProfileViewerDialog.kt
@@ -225,7 +225,7 @@ class ProfileViewerDialog : DaggerDialogFragment() {
             val val1 = Profile.fromMgdlToUnits(profile1.getIsfMgdlTimeFromMidnight(hour * 60 * 60), profile1.units)
             val val2 = Profile.fromMgdlToUnits(profile2.getIsfMgdlTimeFromMidnight(hour * 60 * 60), profile1.units)
             if (val1 != prev1 || val2 != prev2) {
-                s.append(formatColors(Profile.format_HH_MM(hour * 60 * 60), val1, val2, DecimalFormat("0.0"), resourceHelper.gs(R.string.profile_carbs_per_unit)))
+                s.append(formatColors(Profile.format_HH_MM(hour * 60 * 60), val1, val2, DecimalFormat("0.0"), profile1.units + resourceHelper.gs(R.string.profile_per_unit)))
                 s.append("<br>")
             }
             prev1 = val1


### PR DESCRIPTION
@MilosKozak 👍  I like your new "Compareprofile option" and defaultprofile activity
I saw some bugs in your first version : 
- wrong units was displayed for isf value in ProfileViewerDialog (g/U)
- in defaultProfile, units was not added to json file (I think it's better to add it) and isf default values are in mmol units (I added a function to make conversion to selected units)
- datamap is up to 17 (but in profile function it was limited to 16 years old)
Still remain AAPS crash if we select age between 18-80 (I saw you prepared a datamap between 18-24 but not initialized)
=> at info.nightscout.androidaps.data.Profile.init(Profile.java:126) ~[na:0.0]

If you give me your data source for default profiles I can help you to complete this file over 18...

I also quickly made a proposal for a compareprofile icon (vector of course), tell me if you think it could be usefull or if you want something else (not included in this PR)
![CompareProfileIcon](https://user-images.githubusercontent.com/52934600/87165662-bee3bd80-c2ca-11ea-9d23-3ea686192931.jpg)



