### PR TITLE
Inject dependencies in SetPreamble RL command

### DIFF
--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/RFSpy.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/RFSpy.java
@@ -388,7 +388,7 @@ public class RFSpy {
         try {
             resp = writeToData(new SetPreamble(injector, preamble), EXPECTED_MAX_BLUETOOTH_LATENCY_MS);
         } catch (Exception e) {
-            e.toString();
+            aapsLogger.error("Failed to set preamble", e);
         }
         return resp;
     }

--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/command/SetPreamble.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/command/SetPreamble.java
@@ -17,9 +17,10 @@ public class SetPreamble extends RileyLinkCommand {
 
     private int preamble;
 
-
     public SetPreamble(HasAndroidInjector injector, int preamble) throws Exception {
         super();
+
+        injector.androidInjector().inject(this);
 
         // this command was not supported before 2.0
         if (!rileyLinkServiceData.firmwareVersion.isSameVersion(RileyLinkFirmwareVersion.Version2AndHigher)) {


### PR DESCRIPTION
This PR fixes dependency injection in SetPreamble RL command. The dependencies were not being injected which caused a NullPointerException when executing this command.
Also adds proper logging when an Exception occurs: the Exception was caught but not handled or logged.