### PR TITLE
Replace Default Dia by profile Dia in extendedBolus's Iob calculation

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/treatments/TreatmentsPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/treatments/TreatmentsPlugin.java
@@ -273,7 +273,7 @@ public class TreatmentsPlugin extends PluginBase implements TreatmentsInterface 
                 for (int pos = 0; pos < extendedBoluses.size(); pos++) {
                     ExtendedBolus e = extendedBoluses.get(pos);
                     if (e.date > time) continue;
-                    IobTotal calc = e.iobCalc(time);
+                    IobTotal calc = e.iobCalc(time, profile);
                     total.plus(calc);
                 }
             }
@@ -439,9 +439,9 @@ public class TreatmentsPlugin extends PluginBase implements TreatmentsInterface 
                         ExtendedBolus dummyExt = new ExtendedBolus(getInjector());
                         dummyExt.copyFrom(e);
                         dummyExt.cutEndTo(truncateTime);
-                        calc = dummyExt.iobCalc(time);
+                        calc = dummyExt.iobCalc(time, profile);
                     } else {
-                        calc = e.iobCalc(time);
+                        calc = e.iobCalc(time, profile);
                     }
                     totalExt.plus(calc);
                 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/treatments/fragments/TreatmentsExtendedBolusesFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/treatments/fragments/TreatmentsExtendedBolusesFragment.kt
@@ -19,6 +19,7 @@ import info.nightscout.androidaps.db.ExtendedBolus
 import info.nightscout.androidaps.db.Source
 import info.nightscout.androidaps.events.EventExtendedBolusChange
 import info.nightscout.androidaps.interfaces.ActivePluginProvider
+import info.nightscout.androidaps.interfaces.ProfileFunction
 import info.nightscout.androidaps.plugins.bus.RxBusWrapper
 import info.nightscout.androidaps.plugins.general.nsclient.NSUpload
 import info.nightscout.androidaps.plugins.general.nsclient.UploadQueue
@@ -42,6 +43,7 @@ class TreatmentsExtendedBolusesFragment : DaggerFragment() {
     @Inject lateinit var fabricPrivacy: FabricPrivacy
     @Inject lateinit var nsUpload: NSUpload
     @Inject lateinit var uploadQueue: UploadQueue
+    @Inject lateinit var profileFunction: ProfileFunction
     @Inject lateinit var dateUtil: DateUtil
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
@@ -77,16 +79,16 @@ class TreatmentsExtendedBolusesFragment : DaggerFragment() {
                 @SuppressLint("SetTextI18n")
                 if (extendedBolus.isInProgress) holder.date.text = dateUtil.dateAndTimeString(extendedBolus.date)
                 else holder.date.text = dateUtil.dateAndTimeString(extendedBolus.date) + " - " + dateUtil.timeString(extendedBolus.end())
-
+                val profile = profileFunction.getProfile(extendedBolus.date)
                 holder.duration.text = resourceHelper.gs(R.string.format_mins, extendedBolus.durationInMinutes)
                 holder.insulin.text = resourceHelper.gs(R.string.formatinsulinunits, extendedBolus.insulin)
                 holder.realDuration.text = resourceHelper.gs(R.string.format_mins, extendedBolus.realDuration)
-                val iob = extendedBolus.iobCalc(System.currentTimeMillis())
+                val iob = extendedBolus.iobCalc(System.currentTimeMillis(), profile)
                 holder.iob.text = resourceHelper.gs(R.string.formatinsulinunits, iob.iob)
                 holder.insulinSoFar.text = resourceHelper.gs(R.string.formatinsulinunits, extendedBolus.insulinSoFar())
                 holder.ratio.text = resourceHelper.gs(R.string.pump_basebasalrate, extendedBolus.absoluteRate())
                 if (extendedBolus.isInProgress) holder.date.setTextColor(resourceHelper.gc(R.color.colorActive)) else holder.date.setTextColor(holder.insulin.currentTextColor)
-                if (extendedBolus.iobCalc(System.currentTimeMillis()).iob != 0.0) holder.iob.setTextColor(resourceHelper.gc(R.color.colorActive)) else holder.iob.setTextColor(holder.insulin.currentTextColor)
+                if (iob.iob != 0.0) holder.iob.setTextColor(resourceHelper.gc(R.color.colorActive)) else holder.iob.setTextColor(holder.insulin.currentTextColor)
             }
             holder.remove.tag = extendedBolus
         }

--- a/core/src/main/java/info/nightscout/androidaps/db/ExtendedBolus.java
+++ b/core/src/main/java/info/nightscout/androidaps/db/ExtendedBolus.java
@@ -65,6 +65,9 @@ public class ExtendedBolus implements Interval, DataPointWithLabelInterface {
     @DatabaseField
     public int insulinInterfaceID = InsulinInterface.OREF_RAPID_ACTING;
 
+    @DatabaseField
+    public double dia = Constants.defaultDIA;
+
     @Deprecated
     public ExtendedBolus() {
         injector = StaticInjector.Companion.getInstance();

--- a/core/src/main/java/info/nightscout/androidaps/db/ExtendedBolus.java
+++ b/core/src/main/java/info/nightscout/androidaps/db/ExtendedBolus.java
@@ -64,8 +64,6 @@ public class ExtendedBolus implements Interval, DataPointWithLabelInterface {
 
     @DatabaseField
     public int insulinInterfaceID = InsulinInterface.OREF_RAPID_ACTING;
-    @DatabaseField
-    public double dia = Constants.defaultDIA;
 
     @Deprecated
     public ExtendedBolus() {
@@ -229,13 +227,14 @@ public class ExtendedBolus implements Interval, DataPointWithLabelInterface {
         return absoluteRate() * getRealDuration() / 60d;
     }
 
-    public IobTotal iobCalc(long time) {
+    public IobTotal iobCalc(long time, Profile profile) {
         IobTotal result = new IobTotal(time);
         InsulinInterface insulinInterface = activePlugin.getActiveInsulin();
 
         double realDuration = getDurationToTime(time);
 
         if (realDuration > 0) {
+            double dia = profile.getDia();
             double dia_ago = time - dia * 60 * 60 * 1000;
             int aboutFiveMinIntervals = (int) Math.ceil(realDuration / 5d);
             double spacing = realDuration / aboutFiveMinIntervals;
@@ -280,6 +279,7 @@ public class ExtendedBolus implements Interval, DataPointWithLabelInterface {
 
         if (realDuration > 0) {
             double netBasalRate;
+            double dia = profile.getDia();
             double dia_ago = time - dia * 60 * 60 * 1000;
             int aboutFiveMinIntervals = (int) Math.ceil(realDuration / 5d);
             double spacing = realDuration / aboutFiveMinIntervals;


### PR DESCRIPTION
Currently, in `ExtendedBolus.java` file, `dia_ago` is calculated with `contants.defautDIA` (5 hours) and not with profile dia
If profile dia is longer than default dia, each iob contrib is calculated with profile dia in `InsulinOrefBasePlugin` but contribs between Profile dia and default dia are not integrated in extendedBolus's iob calculation...

=> I propose this PR to fix that