### PR TITLE
Store LastRun SMB data in their dedicated fields instead of overwriting TBR fields

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/aps/loop/LoopPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/aps/loop/LoopPlugin.java
@@ -537,11 +537,11 @@ public class LoopPlugin extends PluginBase implements LoopInterface {
                                 applySMBRequest(resultAfterConstraints, new Callback() {
                                     @Override
                                     public void run() {
-                                        //Callback is only called if a bolus was acutally requested
+                                        // Callback is only called if a bolus was actually requested
                                         if (result.enacted || result.success) {
-                                            lastRun.setTbrSetByPump(result);
-                                            lastRun.setLastTBRRequest(lastRun.getLastAPSRun());
-                                            lastRun.setLastTBREnact(DateUtil.now());
+                                            lastRun.setSmbSetByPump(result);
+                                            lastRun.setLastSMBRequest(lastRun.getLastAPSRun());
+                                            lastRun.setLastSMBEnact(DateUtil.now());
                                         } else {
                                             new Thread(() -> {
                                                 SystemClock.sleep(1000);


### PR DESCRIPTION
In LoopPlugin, SMB data would be set in the TBR fields instead of the SMB fields. This PR fixes that and stores the SMB data in their dedicated fields.

In the Loop tab in AAPS, this would cause the TBR fields to contain SMB information, and the SMB fields to always be empty. See below screenshot for an example.

![Screenshot_20200820-110241](https://user-images.githubusercontent.com/15631208/90801050-b5139800-e315-11ea-830b-4c18c763c27c.jpg)