### PR TITLE
Compare targets improvements in ProfileViewerDialog (PROFILE_COMPARE mode)

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/data/Profile.java
+++ b/core/src/main/java/info/nightscout/androidaps/data/Profile.java
@@ -544,6 +544,10 @@ public class Profile {
         return getValueToTime(targetLow_v, timeAsSeconds);
     }
 
+    public double getTargetLowMgdlTimeFromMidnight(int timeAsSeconds) {
+        return toMgdl(getTargetLowTimeFromMidnight(timeAsSeconds), units);
+    }
+
     public double getTargetHighMgdl() {
         return toMgdl(getTargetHighTimeFromMidnight(secondsFromMidnight()), units);
     }
@@ -556,6 +560,10 @@ public class Profile {
         if (targetHigh_v == null)
             targetHigh_v = convertToSparseArray(targetHigh);
         return getValueToTime(targetHigh_v, timeAsSeconds);
+    }
+
+    public double getTargetHighMgdlTimeFromMidnight(int timeAsSeconds) {
+        return toMgdl(getTargetHighTimeFromMidnight(timeAsSeconds), units);
     }
 
     public class TargetValue {

--- a/core/src/main/java/info/nightscout/androidaps/dialogs/ProfileViewerDialog.kt
+++ b/core/src/main/java/info/nightscout/androidaps/dialogs/ProfileViewerDialog.kt
@@ -14,6 +14,7 @@ import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.data.Profile
 import info.nightscout.androidaps.interfaces.ActivePluginProvider
 import info.nightscout.androidaps.interfaces.DatabaseHelperInterface
+import info.nightscout.androidaps.interfaces.ProfileFunction
 import info.nightscout.androidaps.utils.DateUtil
 import info.nightscout.androidaps.utils.DecimalFormatter
 import info.nightscout.androidaps.utils.HtmlHelper
@@ -29,6 +30,7 @@ class ProfileViewerDialog : DaggerDialogFragment() {
     @Inject lateinit var resourceHelper: ResourceHelper
     @Inject lateinit var activePlugin: ActivePluginProvider
     @Inject lateinit var dateUtil: DateUtil
+    @Inject lateinit var profileFunction: ProfileFunction
     @Inject lateinit var databaseHelper: DatabaseHelperInterface
 
     private var time: Long = 0
@@ -117,7 +119,7 @@ class ProfileViewerDialog : DaggerDialogFragment() {
         if (mode == Mode.PROFILE_COMPARE)
             profile?.let { profile1 ->
                 profile2?.let { profile2 ->
-                    profileview_units.text = profile1.units
+                    profileview_units.text = profileFunction.getUnits()
                     profileview_dia.text = HtmlHelper.fromHtml(formatColors("", profile1.dia, profile1.dia, DecimalFormat("0.00"), resourceHelper.gs(R.string.shorthour)))
                     val profileNames =profileName!!.split("\n").toTypedArray()
                     profileview_activeprofile.text = HtmlHelper.fromHtml(formatColors(profileNames[0], profileNames[1]))
@@ -230,7 +232,7 @@ class ProfileViewerDialog : DaggerDialogFragment() {
     private fun isfs(profile1: Profile, profile2: Profile): Spanned {
         var prev1 = 0.0
         var prev2 = 0.0
-        val units = profile1.units
+        val units = profileFunction.getUnits()
         val s = StringBuilder()
         for (hour in 0..23) {
             val val1 = Profile.fromMgdlToUnits(profile1.getIsfMgdlTimeFromMidnight(hour * 60 * 60), units)
@@ -250,7 +252,7 @@ class ProfileViewerDialog : DaggerDialogFragment() {
         var prev1h = 0.0
         var prev2l = 0.0
         var prev2h = 0.0
-        val units = profile1.units
+        val units = profileFunction.getUnits()
         val s = StringBuilder()
         for (hour in 0..23) {
             val val1l = profile1.getTargetLowMgdlTimeFromMidnight(hour * 60 * 60)

--- a/core/src/main/java/info/nightscout/androidaps/dialogs/ProfileViewerDialog.kt
+++ b/core/src/main/java/info/nightscout/androidaps/dialogs/ProfileViewerDialog.kt
@@ -226,7 +226,7 @@ class ProfileViewerDialog : DaggerDialogFragment() {
             prev1 = val1
             prev2 = val2
         }
-        return HtmlHelper.fromHtml(s.toString())
+        return HtmlHelper.fromHtml(s.delete(s.length-4, s.length).toString())
     }
 
     private fun isfs(profile1: Profile, profile2: Profile): Spanned {
@@ -244,7 +244,7 @@ class ProfileViewerDialog : DaggerDialogFragment() {
             prev1 = val1
             prev2 = val2
         }
-        return HtmlHelper.fromHtml(s.toString())
+        return HtmlHelper.fromHtml(s.delete(s.length-4, s.length).toString())
     }
 
     private fun targets(profile1: Profile, profile2: Profile):Spanned {
@@ -270,6 +270,6 @@ class ProfileViewerDialog : DaggerDialogFragment() {
             prev2l = val2l
             prev2h = val2h
         }
-        return HtmlHelper.fromHtml(s.toString())
+        return HtmlHelper.fromHtml(s.delete(s.length-4, s.length).toString())
     }
 }

--- a/core/src/main/java/info/nightscout/androidaps/dialogs/ProfileViewerDialog.kt
+++ b/core/src/main/java/info/nightscout/androidaps/dialogs/ProfileViewerDialog.kt
@@ -259,8 +259,8 @@ class ProfileViewerDialog : DaggerDialogFragment() {
             val val1h = profile1.getTargetHighMgdlTimeFromMidnight(hour * 60 * 60)
             val val2l = profile2.getTargetLowMgdlTimeFromMidnight(hour * 60 * 60)
             val val2h = profile2.getTargetHighMgdlTimeFromMidnight(hour * 60 * 60)
-            val txt1 = Profile.format_HH_MM(hour * 60 * 60) + " " + valueToUnitsToString(val1l, units) + " - " + valueToUnitsToString(val1h, units) + " " + units
-            val txt2 = Profile.format_HH_MM(hour * 60 * 60) + " " + valueToUnitsToString(val2l, units) + " - " + valueToUnitsToString(val2h, units) + " " + units
+            val txt1 = Profile.format_HH_MM(hour * 60 * 60) + " " + Profile.toUnitsString(val1l, val1l * Constants.MGDL_TO_MMOLL, units) + " - " + Profile.toUnitsString(val1h, val1h * Constants.MGDL_TO_MMOLL, units) + " " + units
+            val txt2 = Profile.format_HH_MM(hour * 60 * 60) + " " + Profile.toUnitsString(val2l, val2l * Constants.MGDL_TO_MMOLL, units) + " - " + Profile.toUnitsString(val2h, val2h * Constants.MGDL_TO_MMOLL, units) + " " + units
             if (val1l != prev1l || val1h != prev1h || val2l != prev2l || val2h != prev2h ) {
                 s.append(formatColors(txt1, txt2))
                 s.append("<br>")
@@ -272,9 +272,4 @@ class ProfileViewerDialog : DaggerDialogFragment() {
         }
         return HtmlHelper.fromHtml(s.toString())
     }
-
-    private fun valueToUnitsToString(value: Double, units: String): String? {
-        return if (units == Constants.MGDL) DecimalFormatter.to0Decimal(value) else DecimalFormatter.to1Decimal(value * Constants.MGDL_TO_MMOLL)
-    }
-
 }


### PR DESCRIPTION
See https://github.com/MilosKozak/AndroidAPS/issues/2895
In first commit, I just improve a little bit Target compare between 2 profiles (close to ICs, ISFs or Basals, presentation by hours) and I show both targets in profile1.units (and values rounded according to units)

In second commit, I propose to always show profiles in AAPS units whatever units used for profile1 creation (this modification is limited for PROFILE_COMPARE mode but could be extended to other modes of ProfileViewerDialog if you think it's a good idea...)

After 1rst commit
=> Units used for creation included in the name of profile for mmol (easiest to find it in my LocalProfile list)
=> My AAPS units in preferences = mg/dl
=> Current version on the left, results according to first profile units in the middle and right
![FirstCommit](https://user-images.githubusercontent.com/52934600/90899514-53f8cc80-e3c8-11ea-8f04-d933f9492f6b.jpg)

After second commit, both profiles are shown in AAPS units
![Second commit](https://user-images.githubusercontent.com/52934600/90899515-5529f980-e3c8-11ea-81ba-7928132b70fd.jpg)

