### PR TITLE
Add Manual BG or Calibration in CarePortal Tab of Treatment

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/CareDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/CareDialog.kt
@@ -156,9 +156,9 @@ class CareDialog : DialogFragmentWithDate() {
         if (options == EventType.BGCHECK || options == EventType.QUESTION || options == EventType.ANNOUNCEMENT) {
             val type =
                 when {
-                    actions_care_meter.isChecked  -> "Finger"
-                    actions_care_sensor.isChecked -> "Sensor"
-                    else                          -> "Manual"
+                    actions_care_meter.isChecked  -> CareportalEvent.FINGER
+                    actions_care_sensor.isChecked -> CareportalEvent.SENSOR
+                    else                          -> CareportalEvent.MANUAL
                 }
             actions.add(resourceHelper.gs(R.string.careportal_newnstreatment_glucosetype) + ": " + translator.translate(type))
             actions.add(resourceHelper.gs(R.string.treatments_wizard_bg_label) + ": " + Profile.toCurrentUnitsString(profileFunction, actions_care_bg.value) + " " + resourceHelper.gs(unitResId))

--- a/core/src/main/java/info/nightscout/androidaps/db/CareportalEvent.java
+++ b/core/src/main/java/info/nightscout/androidaps/db/CareportalEvent.java
@@ -78,6 +78,18 @@ public class CareportalEvent implements DataPointWithLabelInterface, Interval {
 
     public static final String MBG = "Mbg"; // comming from entries
 
+    // found in CareDialog.kt file
+    public static final String FINGER = "Finger";
+    public static final String SENSOR = "Sensor";
+    public static final String MANUAL = "Manual";
+
+    // found in Translator.kt
+    public static final String SNACKBOLUS = "Snack Bolus";
+    public static final String SENSORSTART = "Sensor Start";
+    public static final String TEMPBASALSTART = "Temp Basal Start";
+    public static final String TEMPBASALEND = "Temp Basal End";
+    public static final String TEMPBASALCANCEL = "Temporary Target Cancel";
+
     @Deprecated
     public CareportalEvent() {
         StaticInjector.Companion.getInstance().androidInjector().inject(this);

--- a/core/src/main/java/info/nightscout/androidaps/utils/Translator.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/Translator.kt
@@ -1,6 +1,7 @@
 package info.nightscout.androidaps.utils
 
 import info.nightscout.androidaps.core.R
+import info.nightscout.androidaps.db.CareportalEvent
 import info.nightscout.androidaps.utils.resources.ResourceHelper
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,30 +16,32 @@ class Translator @Inject internal constructor(
 
     fun translate(text: String): String =
         when (text) {
-            "BG Check"                -> resourceHelper.gs(R.string.careportal_bgcheck)
-            "Snack Bolus"             -> resourceHelper.gs(R.string.careportal_snackbolus)
-            "Meal Bolus"              -> resourceHelper.gs(R.string.careportal_mealbolus)
-            "Correction Bolus"        -> resourceHelper.gs(R.string.careportal_correctionbolus)
-            "Carb Correction"         -> resourceHelper.gs(R.string.careportal_carbscorrection)
-            "Combo Bolus"             -> resourceHelper.gs(R.string.careportal_combobolus)
-            "Announcement"            -> resourceHelper.gs(R.string.careportal_announcement)
-            "Note"                    -> resourceHelper.gs(R.string.careportal_note)
-            "Question"                -> resourceHelper.gs(R.string.careportal_question)
-            "Exercise"                -> resourceHelper.gs(R.string.careportal_exercise)
-            "Site Change"             -> resourceHelper.gs(R.string.careportal_pumpsitechange)
-            "Pump Battery Change"     -> resourceHelper.gs(R.string.careportal_pumpbatterychange)
-            "Sensor Start"            -> resourceHelper.gs(R.string.careportal_cgmsensorstart)
-            "Sensor Change"           -> resourceHelper.gs(R.string.careportal_cgmsensorinsert)
-            "Insulin Change"          -> resourceHelper.gs(R.string.careportal_insulincartridgechange)
-            "Temp Basal Start"        -> resourceHelper.gs(R.string.careportal_tempbasalstart)
-            "Temp Basal End"          -> resourceHelper.gs(R.string.careportal_tempbasalend)
-            "Profile Switch"          -> resourceHelper.gs(R.string.careportal_profileswitch)
-            "Temporary Target"        -> resourceHelper.gs(R.string.careportal_temporarytarget)
-            "Temporary Target Cancel" -> resourceHelper.gs(R.string.careportal_temporarytargetcancel)
-            "OpenAPS Offline"         -> resourceHelper.gs(R.string.careportal_openapsoffline)
-            "Finger"                  -> resourceHelper.gs(R.string.glucosetype_finger)
-            "Sensor"                  -> resourceHelper.gs(R.string.glucosetype_sensor)
-            "Manual"                  -> resourceHelper.gs(R.string.manual)
-            else                      -> resourceHelper.gs(R.string.unknown)
+            CareportalEvent.BGCHECK             -> resourceHelper.gs(R.string.careportal_bgcheck)
+            CareportalEvent.SNACKBOLUS          -> resourceHelper.gs(R.string.careportal_snackbolus)
+            CareportalEvent.MEALBOLUS           -> resourceHelper.gs(R.string.careportal_mealbolus)
+            CareportalEvent.CORRECTIONBOLUS     -> resourceHelper.gs(R.string.careportal_correctionbolus)
+            CareportalEvent.CARBCORRECTION      -> resourceHelper.gs(R.string.careportal_carbscorrection)
+            CareportalEvent.COMBOBOLUS          -> resourceHelper.gs(R.string.careportal_combobolus)
+            CareportalEvent.ANNOUNCEMENT        -> resourceHelper.gs(R.string.careportal_announcement)
+            CareportalEvent.NOTE                -> resourceHelper.gs(R.string.careportal_note)
+            CareportalEvent.QUESTION            -> resourceHelper.gs(R.string.careportal_question)
+            CareportalEvent.EXERCISE            -> resourceHelper.gs(R.string.careportal_exercise)
+            CareportalEvent.SITECHANGE          -> resourceHelper.gs(R.string.careportal_pumpsitechange)
+            CareportalEvent.PUMPBATTERYCHANGE   -> resourceHelper.gs(R.string.careportal_pumpbatterychange)
+            CareportalEvent.SENSORSTART         -> resourceHelper.gs(R.string.careportal_cgmsensorstart)
+            CareportalEvent.SENSORCHANGE        -> resourceHelper.gs(R.string.careportal_cgmsensorinsert)
+            CareportalEvent.INSULINCHANGE       -> resourceHelper.gs(R.string.careportal_insulincartridgechange)
+            CareportalEvent.TEMPBASALSTART      -> resourceHelper.gs(R.string.careportal_tempbasalstart)
+            CareportalEvent.TEMPBASALEND        -> resourceHelper.gs(R.string.careportal_tempbasalend)
+            CareportalEvent.PROFILESWITCH       -> resourceHelper.gs(R.string.careportal_profileswitch)
+            CareportalEvent.TEMPORARYTARGET     -> resourceHelper.gs(R.string.careportal_temporarytarget)
+            CareportalEvent.TEMPBASALCANCEL     -> resourceHelper.gs(R.string.careportal_temporarytargetcancel)
+            CareportalEvent.OPENAPSOFFLINE      -> resourceHelper.gs(R.string.careportal_openapsoffline)
+            CareportalEvent.MBG                 -> resourceHelper.gs(R.string.careportal_calibration)
+
+            CareportalEvent.FINGER              -> resourceHelper.gs(R.string.glucosetype_finger)
+            CareportalEvent.SENSOR              -> resourceHelper.gs(R.string.glucosetype_sensor)
+            CareportalEvent.MANUAL              -> resourceHelper.gs(R.string.manual)
+            else                                -> resourceHelper.gs(R.string.unknown)
         }
 }

--- a/core/src/main/java/info/nightscout/androidaps/utils/Translator.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/Translator.kt
@@ -37,8 +37,7 @@ class Translator @Inject internal constructor(
             CareportalEvent.TEMPORARYTARGET     -> resourceHelper.gs(R.string.careportal_temporarytarget)
             CareportalEvent.TEMPBASALCANCEL     -> resourceHelper.gs(R.string.careportal_temporarytargetcancel)
             CareportalEvent.OPENAPSOFFLINE      -> resourceHelper.gs(R.string.careportal_openapsoffline)
-            CareportalEvent.MBG                 -> resourceHelper.gs(R.string.careportal_calibration)
-
+            CareportalEvent.MBG                 -> resourceHelper.gs(R.string.careportal_mbg)
             CareportalEvent.FINGER              -> resourceHelper.gs(R.string.glucosetype_finger)
             CareportalEvent.SENSOR              -> resourceHelper.gs(R.string.glucosetype_sensor)
             CareportalEvent.MANUAL              -> resourceHelper.gs(R.string.manual)

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -163,6 +163,7 @@
 
     <!--    Translator-->
     <string name="careportal_bgcheck">BG Check</string>
+    <string name="careportal_calibration">Calibration</string>
     <string name="careportal_announcement">Announcement</string>
     <string name="careportal_note">Note</string>
     <string name="careportal_question">Question</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -163,7 +163,7 @@
 
     <!--    Translator-->
     <string name="careportal_bgcheck">BG Check</string>
-    <string name="careportal_calibration">Calibration</string>
+    <string name="careportal_mbg">Manual BG or Calibration</string>
     <string name="careportal_announcement">Announcement</string>
     <string name="careportal_note">Note</string>
     <string name="careportal_question">Question</string>


### PR DESCRIPTION
Fix https://github.com/MilosKozak/AndroidAPS/issues/2912

![Calibration event added in CarePortal Tab](https://user-images.githubusercontent.com/52934600/90961122-ea9bbb00-e4a6-11ea-9655-353b13f15c6a.jpg)

I found in Translator.kt 5 types of event that was in previous Careportal Plugin (I don't know if we can delete them)
Strings found in translator.kt replaced by Constants defined in CareportalEvent.java file (I think it's better...)