### PR TITLE
Change obj. 9 + remove skipping objectives

### DIFF
--- a/app/src/main/res/values/objectives.xml
+++ b/app/src/main/res/values/objectives.xml
@@ -50,7 +50,7 @@
     <string name="objectives_useloop">Display content of Loop plugin</string>
     <string name="objectives_usescale">Use scale function by long-pressing BG chart</string>
     <string name="objectives_button_enter">Enter</string>
-    <string name="enter_code_obtained_from_developers_to_bypass_the_rest_of_objectives">If you have at least 3 month of closed loop experience with other systems you might qualify for a code to skip objectives. See https://androidaps.readthedocs.io/en/latest/EN/Usage/Objectives.html#skip-objectives for details.</string>
+    <string name="enter_code_obtained_from_developers_to_bypass_the_rest_of_objectives">Skipping objectives is not available for the time being.</string>
     <string name="codeaccepted">Code accepted</string>
     <string name="codeinvalid">Code invalid</string>
     <string name="objectives_exam_objective">Prove your knowledge</string>

--- a/app/src/main/res/values/objectives.xml
+++ b/app/src/main/res/values/objectives.xml
@@ -30,10 +30,11 @@
     <string name="objectives_maxiob_gate">Run for a few days, and at least one night with no low BG alarms, before dropping BG</string>
     <string name="objectives_autosens_objective">Adjust basals and ratios if needed, and then enable auto-sens</string>
     <string name="objectives_autosens_gate">1 week successful daytime looping with regular carb entry</string>
-    <string name="objectives_ama_objective">Enabling additional features for daytime use, such as advanced meal assist</string>
+    <string name="objectives_ama_objective">Try additional features for daytime use and gain confidence in your closed loop system</string>
     <string name="objectives_smb_objective">Enabling additional features for daytime use, such as SMB</string>
     <string name="objectives_auto_objective">Enabling automation</string>
-    <string name="objectives_smb_gate">You must read the wiki and rise maxIOB to get SMBs working fine! A good start is maxIOB=average mealbolus + 3 x max daily basal</string>
+    <string name="objectives_ama_gate">Before AAPS version 2.7 meal assist (MA) was the basic algorithm for AAPS and completing objective 8 was necessary to activate advanced meal assist (AMA). As AMA is the standard algorithm from AAPS version 2.7 onwards use the following 28 days to try features you haven't used yet and get more confident with you closed loop system.</string>
+    <string name="objectives_smb_gate">You must read the docs and rise maxIOB to get SMBs working fine! A good start is maxIOB=average mealbolus + 3 x max daily basal</string>
     <string name="objectives_auto_gate">Read the docs how automation works. Setup your first simple rules. Instead of action let AAPS display only notification. When you are sure automation is triggered at the right time replace notification by real action. (https://androidaps.readthedocs.io/en/latest/EN/Usage/Automation.html)</string>
     <string name="objectives_bgavailableinns">BG available in NS</string>
     <string name="objectives_pumpstatusavailableinns">Pump status available in NS</string>


### PR DESCRIPTION
- MA is eliminated in 2.7
- AMA is standard algo
- Basically obj. 9 is no longer needed but still there
- Tried to write an explenation (see also docs 2.7 https://github.com/openaps/AndroidAPSdocs/blob/2.7_docs/docs/EN/Usage/Objectives.rst#objective-9-try-additional-features-for-daytime-use-and-gain-confidence-in-your-closed-loop-system)
- New string "objectives_ama_gate" (Don't know if it is that easy to implement but looked how it works for obj. 10 / smb)